### PR TITLE
feat: 관리자 enum 및 Admin 엔티티 추가/Role.Status 및 Admin 테이블 매핑

### DIFF
--- a/src/main/java/com/example/commercepilot/admin/entity/Admin.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/Admin.java
@@ -1,4 +1,73 @@
 package com.example.commercepilot.admin.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "admin")
 public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "admin_name", nullable = false, length = 50)
+    private String adminName;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "call_number", nullable = false, length = 20)
+    private String callNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private AdminRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private AdminStatus status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    // ERD에서 admin 테이블에 superAdmin_id (FK) 있었으니 일단 ID만 들고감 (단방향 조건)
+    @Column(name = "super_admin_id")
+    private Long superAdminId;
+
+    public static Admin pending(
+            String adminName,
+            String email,
+            String encodedPassword,
+            String callNumber,
+            AdminRole role
+    ) {
+        Admin admin = new Admin();
+        admin.adminName = adminName;
+        admin.email = email;
+        admin.password = encodedPassword;
+        admin.callNumber = callNumber;
+        admin.role = role;
+        admin.status = AdminStatus.PENDING;
+        return admin;
+    }
+
+    @PrePersist
+    void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.modifiedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.modifiedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/commercepilot/admin/entity/AdminRole.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/AdminRole.java
@@ -1,0 +1,7 @@
+package com.example.commercepilot.admin.entity;
+
+public enum AdminRole {
+    SUPER_ADMIN,
+    OPERATION_ADMIN,
+    CS_ADMIN
+}

--- a/src/main/java/com/example/commercepilot/admin/entity/AdminStatus.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/AdminStatus.java
@@ -1,0 +1,9 @@
+package com.example.commercepilot.admin.entity;
+
+public enum AdminStatus {
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED,
+    PENDING,
+    REJECTED
+}

--- a/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
@@ -1,4 +1,4 @@
-package com.example.commercepilot.admin.dto;
+package com.example.commercepilot.admin.service;
 
 public class AdminCommandService {
 }

--- a/src/main/java/com/example/commercepilot/orders/entity/Order.java
+++ b/src/main/java/com/example/commercepilot/orders/entity/Order.java
@@ -7,16 +7,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SoftDelete;
 
-<<<<<<< Updated upstream
-import java.util.ArrayList;
 
-=======
-@SoftDelete(columnName = "is_deleted")
->>>>>>> Stashed changes
 @Getter
 @Entity
 @Table(name = "orders")
-@SoftDelete(columnName = "isdeleted")
+@SoftDelete(columnName = "is_deleted")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
 


### PR DESCRIPTION
## 💡 개요
- 관리자 도메인 enum(AdminRole/AdminStatus) 및 Admin 엔티티 추가

## 🛠️ 작업 내용
- AdminRole enum 추가 (SUPER_ADMIN, OPERATION_ADMIN, CS_ADMIN)
- AdminStatus enum 추가 (ACTIVE, INACTIVE, SUSPENDED, PENDING, REJECTED)
- Admin 엔티티 생성 및 ERD 기반 필드 매핑(createdAt/modifiedAt, superAdminId 포함)

## 💬 리뷰 포인트
- Admin 엔티티 컬럼명/테이블명(admin) 및 createdAt/modifiedAt 처리(@PrePersist/@PreUpdate)가 팀 컨벤션과 맞는지 확인 부탁드립니다.
- superAdminId를 연관관계 대신 Long FK로 들고가는 방식(단방향 최소)이 괜찮은지 의견 부탁드립니다.


- Closes: # 
