### PR TITLE
feat: 관리자 회원가입 서비스 및 컨트롤러 구현 / 중복검증,암호화,POST /admins/sign추가

### DIFF
--- a/src/main/java/com/example/commercepilot/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/example/commercepilot/admin/controller/AdminAuthController.java
@@ -1,4 +1,24 @@
 package com.example.commercepilot.admin.controller;
 
+import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
+import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
+import com.example.commercepilot.admin.service.AdminCommandService;
+import com.example.commercepilot.exception.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admins")
 public class AdminAuthController {
+
+    private final AdminCommandService adminCommandService;
+
+    @PostMapping("/signup")
+    public ApiResponse<AdminSignupResponse> signup(@Valid @RequestBody AdminSignupRequest request) {
+        AdminSignupResponse response = adminCommandService.signup(request);
+        return ApiResponse.success(HttpStatus.CREATED, response);
+    }
 }

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminSignupRequest.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminSignupRequest.java
@@ -1,4 +1,4 @@
-package com.example.commercepilot.admin.dto;
+package com.example.commercepilot.admin.dto.request;
 
 import com.example.commercepilot.admin.entity.AdminRole;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/example/commercepilot/admin/dto/response/AdminSignupResponse.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/response/AdminSignupResponse.java
@@ -1,4 +1,4 @@
-package com.example.commercepilot.admin.dto;
+package com.example.commercepilot.admin.dto.response;
 
 import com.example.commercepilot.admin.entity.Admin;
 import com.example.commercepilot.admin.entity.AdminRole;

--- a/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
@@ -1,4 +1,41 @@
 package com.example.commercepilot.admin.service;
 
+import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
+import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.repository.AdminRepository;
+import com.example.commercepilot.config.PasswordEncoder;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class AdminCommandService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public AdminSignupResponse signup(AdminSignupRequest request) {
+
+        if (adminRepository.existsByEmail(request.email())) {
+            throw new CustomException(ErrorCode.ADMIN_EMAIL_DUPLICATED);
+        }
+
+        String encoded = passwordEncoder.encode(request.password());
+
+        Admin admin = Admin.pending(
+                request.name(),
+                request.email(),
+                encoded,
+                request.callNumber(),
+                request.role()
+        );
+
+        Admin saved = adminRepository.save(admin);
+        return AdminSignupResponse.from(saved);
+    }
 }


### PR DESCRIPTION
## 💡 개요
- 관리자 회원가입 서비스 및 컨트롤러 구현

## 🛠️ 작업 내용
- AdminCommandService 구현 (이메일 중복 검증, 비밀번호 암호화, PENDING 상태 저장)
- AdminAuthController 구현 (POST /admins/signup)
- DTO 구조 request/response 패키지 분리

## 📷 스크린샷 (UI가 변경된 경우)
- 없음 (API 작업)

## 💬 리뷰 포인트
- 중복 이메일 검증 로직 위치(Service) 적절성 확인 부탁드립니다.
- 비밀번호 암호화 처리 방식(PasswordEncoder 사용)이 팀 컨벤션에 맞는지 확인 부탁드립니다.
- DTO request/response 패키지 분리 구조 확인 부탁드립니다.
