### PR TITLE
feat: 관리자 세션 상수 및 LoginAdmin DTO 추가 / 세션 인증 기반 준비

### DIFF
--- a/src/main/java/com/example/commercepilot/admin/config/SessionConst.java
+++ b/src/main/java/com/example/commercepilot/admin/config/SessionConst.java
@@ -1,0 +1,7 @@
+package com.example.commercepilot.admin.config;
+
+public final class SessionConst {
+    private SessionConst() {}
+
+    public static final String LOGIN_ADMIN = "LOGIN_ADMIN";
+}

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,16 @@
+package com.example.commercepilot.admin.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminLoginRequest(
+
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email,
+
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/src/main/java/com/example/commercepilot/admin/dto/session/LoginAdmin.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/session/LoginAdmin.java
@@ -1,0 +1,9 @@
+package com.example.commercepilot.admin.dto.session;
+
+import com.example.commercepilot.admin.entity.AdminRole;
+
+public record LoginAdmin(
+        Long adminId,
+        String email,
+        AdminRole role
+) {}


### PR DESCRIPTION
## 💡 개요
- 관리자 세션 인증을 위한 상수 및 세션 저장 DTO 추가

## 🛠️ 작업 내용
- SessionConst 추가 (LOGIN_ADMIN 세션 키 정의)
- LoginAdmin 세션 DTO 추가 (adminId/email/role)

## 📷 스크린샷 (UI가 변경된 경우)
- 없음

## 💬 리뷰 포인트
- 세션 키 네이밍(LOGIN_ADMIN) 및 세션 저장 필드 범위가 적절한지 확인 부탁드립니다.
