### PR TITLE
feat: 관리자 로그인/로그아웃 API 추가 / POST /admins/login,logout 구현

### DIFF
--- a/src/main/java/com/example/commercepilot/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/example/commercepilot/admin/controller/AdminAuthController.java
@@ -1,9 +1,12 @@
 package com.example.commercepilot.admin.controller;
 
+import com.example.commercepilot.admin.dto.request.AdminLoginRequest;
 import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
 import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
+import com.example.commercepilot.admin.service.AdminAuthService;
 import com.example.commercepilot.admin.service.AdminCommandService;
 import com.example.commercepilot.exception.ApiResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,10 +18,23 @@ import org.springframework.web.bind.annotation.*;
 public class AdminAuthController {
 
     private final AdminCommandService adminCommandService;
+    private final AdminAuthService adminAuthService;
 
     @PostMapping("/signup")
     public ApiResponse<AdminSignupResponse> signup(@Valid @RequestBody AdminSignupRequest request) {
         AdminSignupResponse response = adminCommandService.signup(request);
         return ApiResponse.success(HttpStatus.CREATED, response);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<Void> login(@Valid @RequestBody AdminLoginRequest request, HttpSession session) {
+        adminAuthService.login(request, session);
+        return ApiResponse.success(HttpStatus.OK);
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(HttpSession session) {
+        adminAuthService.logout(session);
+        return ApiResponse.success(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/commercepilot/exception/ErrorCode.java
+++ b/src/main/java/com/example/commercepilot/exception/ErrorCode.java
@@ -24,6 +24,15 @@ public enum ErrorCode {
     ADMIN_SUSPENDED(HttpStatus.FORBIDDEN, "M006", "정지된 계정입니다."),
     ADMIN_INACTIVE(HttpStatus.FORBIDDEN, "M007", "비활성화된 계정입니다."),
 
+    // 상품 관련 에러 코드("P###")
+    PRODUCT_DISCONTINUED(HttpStatus.BAD_REQUEST, "P001", "단종된 상품입니다."),
+    PRODUCT_SOLD_OUT(HttpStatus.BAD_REQUEST, "P002", "품절된 상품입니다."),
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "P003", "재고가 부족합니다."),
+
+    // 고객 관련 에러 코드("CU###")
+    CUSTOMER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CU001", "고객 ID는 필수입니다."),
+    CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "CU002", "해당 고객을 찾을 수 없습니다."),
+
 //    유저 관련 에러 코드("U###")
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "해당 유저는 존재하지 않습니다"),
 


### PR DESCRIPTION
## 💡 개요
- 관리자 로그인/로그아웃 API 컨트롤러 구현 (세션 기반)

## 🛠️ 작업 내용
- POST /admins/login 추가 (AdminAuthService 연동, 세션 생성)
- POST /admins/logout 추가 (세션 무효화)
- 기존 POST /admins/signup 유지

## 📷 스크린샷 (UI가 변경된 경우)
- 없음 (API 작업)

## 💬 리뷰 포인트
- login/logout 응답을 ApiResponse.success(데이터 없음) 형태로 반환하는 방식이 팀 컨벤션과 맞는지 확인 부탁드립니다.
- login 요청 시 HttpSession을 컨트롤러에서 주입받아 전달하는 구조가 적절한지 확인 부탁드립니다.