### PR TITLE
feat: 주문 엔티티 수정 및 CUD 구현 완료

### DIFF
--- a/src/main/java/com/example/commercepilot/orders/controller/OrderController.java
+++ b/src/main/java/com/example/commercepilot/orders/controller/OrderController.java
@@ -1,16 +1,25 @@
 package com.example.commercepilot.orders.controller;
 
+import com.example.commercepilot.exception.ApiResponse;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
+import com.example.commercepilot.orders.dto.request.OrderCreateRequest;
+import com.example.commercepilot.orders.dto.request.OrderDeleteRequest;
 import com.example.commercepilot.orders.dto.request.OrderSearchRequest;
+import com.example.commercepilot.orders.dto.response.OrderCreateResponse;
+import com.example.commercepilot.orders.dto.response.OrderDeleteResponse;
 import com.example.commercepilot.orders.dto.response.OrderListResponse;
+import com.example.commercepilot.orders.dto.response.OrderUpdateResponse;
+import com.example.commercepilot.orders.dto.session.SessionAdmin;
+import com.example.commercepilot.orders.dto.session.SessionCustomer;
 import com.example.commercepilot.orders.service.OrderQueryService;
+import com.example.commercepilot.orders.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,11 +27,53 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
     private final OrderQueryService orderQueryService;
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderCreateResponse>> createOrder(
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
+            @SessionAttribute(name = "loginCustomer", required = false) SessionCustomer sessionCustomer,
+            @Valid @RequestBody OrderCreateRequest request
+    ) {
+        if (sessionAdmin == null && sessionCustomer == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, orderService.add(sessionAdmin, sessionCustomer, request)));
+    }
 
 
     @GetMapping
     public ResponseEntity<Page<OrderListResponse>> getOrders(
             @Valid @ModelAttribute OrderSearchRequest request) {
         return ResponseEntity.ok(orderQueryService.getOrders(request));
+    }
+
+    @PutMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderUpdateResponse>> updateOrder(
+            @PathVariable Long orderId,
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin
+    ) {
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(HttpStatus.OK, orderService.update(orderId)));
+    }
+
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderDeleteResponse>> deleteOrder(
+            @PathVariable Long orderId,
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
+            @SessionAttribute(name = "loginCustomer", required = false) SessionCustomer sessionCustomer,
+            @Valid @RequestBody OrderDeleteRequest request
+    ) {
+        if (sessionAdmin == null && sessionCustomer == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(HttpStatus.OK, orderService.delete(orderId, sessionAdmin, sessionCustomer, request)));
     }
 }

--- a/src/main/java/com/example/commercepilot/orders/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/request/OrderCreateRequest.java
@@ -1,0 +1,11 @@
+package com.example.commercepilot.orders.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record OrderCreateRequest(
+        Long customerId,
+        Long productId,
+        @Min(value = 1, message = "주문 수량은 최소 1개 이상이어야 합니다.")
+        int quantity
+) {
+}

--- a/src/main/java/com/example/commercepilot/orders/dto/request/OrderDeleteRequest.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/request/OrderDeleteRequest.java
@@ -1,0 +1,9 @@
+package com.example.commercepilot.orders.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record OrderDeleteRequest(
+        @NotBlank(message = "취소 사유는 필수입니다.")
+        String cancelText
+) {
+}

--- a/src/main/java/com/example/commercepilot/orders/dto/request/OrderSearchRequest.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/request/OrderSearchRequest.java
@@ -1,6 +1,7 @@
 package com.example.commercepilot.orders.dto.request;
 
 import com.example.commercepilot.orders.entity.Order;
+import com.example.commercepilot.orders.entity.OrderStatus;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
@@ -20,5 +21,5 @@ public class OrderSearchRequest {
 
     private String sortBy = "createdAt";             // 정렬 기준: quantity, totalPrice, createdAt
     private String sortDir = "desc";                 // 정렬 순서: asc, desc
-    private Order.OrderStatus status;                // 상태 필터
+    private OrderStatus status;                // 상태 필터
 }

--- a/src/main/java/com/example/commercepilot/orders/dto/response/OrderCreateResponse.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/response/OrderCreateResponse.java
@@ -1,0 +1,22 @@
+package com.example.commercepilot.orders.dto.response;
+
+import com.example.commercepilot.orders.entity.Order;
+import com.example.commercepilot.orders.entity.OrderStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record OrderCreateResponse(
+        Long id, OrderStatus status, Long totalPrice, LocalDateTime createdAt
+) {
+
+    public static OrderCreateResponse from(Order order) {
+        return OrderCreateResponse.builder()
+                .id(order.getId())
+                .status(order.getStatus())
+                .totalPrice(order.getTotalPrice())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/commercepilot/orders/dto/response/OrderDeleteResponse.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/response/OrderDeleteResponse.java
@@ -1,0 +1,22 @@
+package com.example.commercepilot.orders.dto.response;
+
+import com.example.commercepilot.orders.entity.Order;
+import lombok.Builder;
+
+@Builder
+public record OrderDeleteResponse(
+        Long orderId,
+        String productName,
+        int quantity,
+        Long totalPrice
+) {
+
+    public static OrderDeleteResponse from(Order order) {
+        return OrderDeleteResponse.builder()
+                .orderId(order.getId())
+                .productName(order.getProduct().getName())
+                .stock(order.getQuantity())
+                .totalPrice(order.getTotalPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/example/commercepilot/orders/dto/response/OrderDeleteResponse.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/response/OrderDeleteResponse.java
@@ -15,7 +15,7 @@ public record OrderDeleteResponse(
         return OrderDeleteResponse.builder()
                 .orderId(order.getId())
                 .productName(order.getProduct().getName())
-                .stock(order.getQuantity())
+                .quantity(order.getQuantity())
                 .totalPrice(order.getTotalPrice())
                 .build();
     }

--- a/src/main/java/com/example/commercepilot/orders/dto/response/OrderListResponse.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/response/OrderListResponse.java
@@ -1,6 +1,7 @@
 package com.example.commercepilot.orders.dto.response;
 
 import com.example.commercepilot.orders.entity.Order;
+import com.example.commercepilot.orders.entity.OrderStatus;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -15,7 +16,7 @@ public class OrderListResponse {
     private final int quantity;
     private final Long totalPrice;
     private final LocalDateTime orderedAt;
-    private final Order.OrderStatus status;
+    private final OrderStatus status;
     private final String adminName;
 
     private OrderListResponse(Order order) {

--- a/src/main/java/com/example/commercepilot/orders/dto/response/OrderUpdateResponse.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/response/OrderUpdateResponse.java
@@ -1,0 +1,23 @@
+package com.example.commercepilot.orders.dto.response;
+
+import com.example.commercepilot.orders.entity.Order;
+import com.example.commercepilot.orders.entity.OrderStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record OrderUpdateResponse(
+        Long id, OrderStatus status, Long totalPrice, LocalDateTime createdAt, LocalDateTime modifiedAt
+) {
+
+    public static OrderUpdateResponse from(Order order) {
+        return OrderUpdateResponse.builder()
+                .id(order.getId())
+                .status(order.getStatus())
+                .totalPrice(order.getTotalPrice())
+                .createdAt(order.getCreatedAt())
+                .modifiedAt(order.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/commercepilot/orders/dto/session/SessionAdmin.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/session/SessionAdmin.java
@@ -1,0 +1,7 @@
+package com.example.commercepilot.orders.dto.session;
+
+public record SessionAdmin(
+        Long adminId,
+        String role
+) {
+}

--- a/src/main/java/com/example/commercepilot/orders/dto/session/SessionAdmin.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/session/SessionAdmin.java
@@ -1,7 +1,9 @@
 package com.example.commercepilot.orders.dto.session;
 
+import com.example.commercepilot.admin.entity.AdminRole;
+
 public record SessionAdmin(
         Long adminId,
-        String role
+        AdminRole role
 ) {
 }

--- a/src/main/java/com/example/commercepilot/orders/dto/session/SessionCustomer.java
+++ b/src/main/java/com/example/commercepilot/orders/dto/session/SessionCustomer.java
@@ -1,0 +1,7 @@
+package com.example.commercepilot.orders.dto.session;
+
+public record SessionCustomer(
+        Long customerId,
+        String role
+) {
+}

--- a/src/main/java/com/example/commercepilot/orders/entity/Order.java
+++ b/src/main/java/com/example/commercepilot/orders/entity/Order.java
@@ -1,5 +1,6 @@
 package com.example.commercepilot.orders.entity;
 
+import com.example.commercepilot.admin.entity.Admin;
 import com.example.commercepilot.config.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -7,6 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SoftDelete;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 
 @Getter
 @Entity
@@ -15,29 +19,54 @@ import org.hibernate.annotations.SoftDelete;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, unique = true, updatable = false, length = 20)
+    private String orderNumber;
     private Long totalPrice;
+    private int quantity;
+    private String cancelText;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "customer_id", nullable = false)
     private Customer customer;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "admin_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
     private Admin admin;
 
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
-    public enum OrderStatus {
-        PENDING, CONFIRMED, SHIPPING, DELIVERED, CANCELLED
+    @PrePersist
+    public void createOrderNumber() {
+        String datePart = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String randomPart = UUID.randomUUID().toString().toUpperCase().substring(0, 8);
+
+        this.orderNumber = datePart + "-" + randomPart;
+    }
+
+    public Order(Long totalPrice, int quantity, Customer customer, Product product, Admin admin, OrderStatus status) {
+        this.totalPrice = totalPrice;
+        this.quantity = quantity;
+        this.customer = customer;
+        this.product = product;
+        this.admin = admin;
+        this.status = status;
+    }
+
+    public void changeStatus(OrderStatus orderStatus) {
+        this.status = orderStatus;
+    }
+
+    public void cancel(String cancelText) {
+        this.status = OrderStatus.CANCELLED;
+        this.cancelText = cancelText;
     }
 }
 

--- a/src/main/java/com/example/commercepilot/orders/entity/Order.java
+++ b/src/main/java/com/example/commercepilot/orders/entity/Order.java
@@ -2,6 +2,8 @@ package com.example.commercepilot.orders.entity;
 
 import com.example.commercepilot.admin.entity.Admin;
 import com.example.commercepilot.config.BaseEntity;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -60,8 +62,14 @@ public class Order extends BaseEntity {
         this.status = status;
     }
 
-    public void changeStatus(OrderStatus orderStatus) {
-        this.status = orderStatus;
+    public void proceed() {
+        if (this.status == OrderStatus.PENDING) {
+            this.status = OrderStatus.SHIPPING;
+        } else if (this.status == OrderStatus.SHIPPING) {
+            this.status = OrderStatus.DELIVERED;
+        } else {
+            throw new CustomException(ErrorCode.ORDER_STATUS_NOT_CHANGEABLE);
+        }
     }
 
     public void cancel(String cancelText) {

--- a/src/main/java/com/example/commercepilot/orders/entity/OrderStatus.java
+++ b/src/main/java/com/example/commercepilot/orders/entity/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.example.commercepilot.orders.entity;
+
+public enum OrderStatus {
+    PENDING,
+    SHIPPING,
+    DELIVERED,
+    CANCELLED
+}

--- a/src/main/java/com/example/commercepilot/orders/repository/OrderRepository.java
+++ b/src/main/java/com/example/commercepilot/orders/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.example.commercepilot.orders.repository;
 
 import com.example.commercepilot.orders.entity.Order;
+import com.example.commercepilot.orders.entity.OrderStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,10 +11,10 @@ import org.springframework.data.repository.query.Param;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @Query("SELECT o FROM Order o JOIN FETCH o.customer c " +
-           "WHERE (:keyword IS NULL OR o.orderNumber LIKE %:keyword% OR c.name LIKE %:keyword%) " +
-           "AND (:status IS NULL OR o.status = :status)")
+            "WHERE (:keyword IS NULL OR o.orderNumber LIKE %:keyword% OR c.name LIKE %:keyword%) " +
+            "AND (:status IS NULL OR o.status = :status)")
     Page<Order> findByKeywordAndStatus(
             @Param("keyword") String keyword,
-            @Param("status") Order.OrderStatus status,
+            @Param("status") OrderStatus status,
             Pageable pageable);
 }

--- a/src/main/java/com/example/commercepilot/orders/service/OrderService.java
+++ b/src/main/java/com/example/commercepilot/orders/service/OrderService.java
@@ -1,0 +1,127 @@
+package com.example.commercepilot.orders.service;
+
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.repository.AdminRepository;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
+import com.example.commercepilot.orders.dto.request.OrderCreateRequest;
+import com.example.commercepilot.orders.dto.request.OrderDeleteRequest;
+import com.example.commercepilot.orders.dto.response.OrderCreateResponse;
+import com.example.commercepilot.orders.dto.response.OrderDeleteResponse;
+import com.example.commercepilot.orders.dto.response.OrderUpdateResponse;
+import com.example.commercepilot.orders.dto.session.SessionAdmin;
+import com.example.commercepilot.orders.dto.session.SessionCustomer;
+import com.example.commercepilot.orders.entity.Order;
+import com.example.commercepilot.orders.entity.OrderStatus;
+import com.example.commercepilot.orders.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final AdminRepository adminRepository;
+    private final ProductRepository productRepository;
+    private final CustomerRepository customerRepository;
+
+    @Transactional
+    public OrderCreateResponse add(SessionAdmin sessionAdmin, SessionCustomer sessionCustomer, OrderCreateRequest request) {
+        Product product = productRepository.findById(request.productId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        long price = product.getPrice();
+        int stock = product.getStock();
+        ProductStatus productStatus = product.getStatus();
+
+        if (productStatus == ProductStatus.DISCONTINUED) {
+            throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
+        }
+        if (productStatus == ProductStatus.SOLD_OUT) {
+            throw new CustomException(ErrorCode.PRODUCT_SOLD_OUT);
+        }
+        if (stock < request.quantity()) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_STOCK);
+        }
+
+        long totalPrice = request.quantity() * price;
+
+        if (sessionCustomer != null) {
+            Customer customer = customerRepository.findById(sessionCustomer.customerId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
+
+            product.decreaseStock(request.quantity());
+
+            Order order = new Order(totalPrice, request.quantity(), customer, product, null, OrderStatus.PENDING);
+
+            Order savedOrder = orderRepository.save(order);
+
+            return OrderCreateResponse.from(savedOrder);
+        } else if (!"CS_ADMIN".equals(sessionAdmin.role())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        if (request.customerId() == null) {
+            throw new CustomException(ErrorCode.CUSTOMER_ID_REQUIRED);
+        }
+
+        Admin admin = adminRepository.findById(sessionAdmin.adminId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        Customer customer = customerRepository.findById(request.customerId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
+
+        product.decreaseStock(request.quantity());
+
+        Order order = new Order(totalPrice, request.quantity(), customer, product, admin, OrderStatus.PENDING);
+
+        Order savedOrder = orderRepository.save(order);
+
+        return OrderCreateResponse.from(savedOrder);
+    }
+
+    @Transactional
+    public OrderUpdateResponse update(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderStatus status = order.getStatus();
+
+        if (status == OrderStatus.PENDING) {
+            status = OrderStatus.SHIPPING;
+        } else if (status == OrderStatus.SHIPPING) {
+            status = OrderStatus.DELIVERED;
+        } else {
+            throw new CustomException(ErrorCode.ORDER_STATUS_NOT_CHANGEABLE);
+        }
+
+        order.changeStatus(status);
+
+        return OrderUpdateResponse.from(order);
+    }
+
+    @Transactional
+    public OrderDeleteResponse delete(Long orderId, SessionAdmin sessionAdmin, SessionCustomer sessionCustomer, OrderDeleteRequest request) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        Long customerId = order.getCustomer().getId();
+
+        if (sessionCustomer != null && !sessionCustomer.customerId().equals(customerId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        if (!order.getStatus().equals(OrderStatus.PENDING)) {
+            throw new CustomException(ErrorCode.ORDER_CANCLE_NOT_ALLOWED);
+        }
+
+        Product product = order.getProduct();
+        product.addStock(order.getQuantity());
+
+        order.cancel(request.cancelText());
+
+        return OrderDeleteResponse.from(order);
+    }
+}

--- a/src/main/java/com/example/commercepilot/orders/service/OrderService.java
+++ b/src/main/java/com/example/commercepilot/orders/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.example.commercepilot.orders.service;
 
 import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.entity.AdminRole;
 import com.example.commercepilot.admin.repository.AdminRepository;
 import com.example.commercepilot.exception.CustomException;
 import com.example.commercepilot.exception.ErrorCode;
@@ -14,6 +15,7 @@ import com.example.commercepilot.orders.dto.session.SessionCustomer;
 import com.example.commercepilot.orders.entity.Order;
 import com.example.commercepilot.orders.entity.OrderStatus;
 import com.example.commercepilot.orders.repository.OrderRepository;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,8 +35,38 @@ public class OrderService {
         Product product = productRepository.findById(request.productId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        long price = product.getPrice();
-        int stock = product.getStock();
+        validateProduct(product, request.quantity());
+
+        long totalPrice = request.quantity() * product.getPrice();
+
+        Customer customer;
+        Admin admin = null;
+
+        if (sessionCustomer != null) {
+            customer = customerRepository.findById(sessionCustomer.customerId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
+        } else {
+            if (sessionAdmin.role() != AdminRole.CS_ADMIN) {
+                throw new CustomException(ErrorCode.FORBIDDEN);
+            }
+            if (request.customerId() == null) {
+                throw new CustomException(ErrorCode.CUSTOMER_ID_REQUIRED);
+            }
+            admin = adminRepository.findById(sessionAdmin.adminId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+            customer = customerRepository.findById(request.customerId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
+        }
+
+        product.decreaseStock(request.quantity());
+
+        Order order = new Order(totalPrice, request.quantity(), customer, product, admin, OrderStatus.PENDING);
+        Order savedOrder = orderRepository.save(order);
+
+        return OrderCreateResponse.from(savedOrder);
+    }
+
+    private void validateProduct(Product product, int quantity) {
         ProductStatus productStatus = product.getStatus();
 
         if (productStatus == ProductStatus.DISCONTINUED) {
@@ -46,41 +78,6 @@ public class OrderService {
         if (stock < request.quantity()) {
             throw new CustomException(ErrorCode.INSUFFICIENT_STOCK);
         }
-
-        long totalPrice = request.quantity() * price;
-
-        if (sessionCustomer != null) {
-            Customer customer = customerRepository.findById(sessionCustomer.customerId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
-
-            product.decreaseStock(request.quantity());
-
-            Order order = new Order(totalPrice, request.quantity(), customer, product, null, OrderStatus.PENDING);
-
-            Order savedOrder = orderRepository.save(order);
-
-            return OrderCreateResponse.from(savedOrder);
-        } else if (!"CS_ADMIN".equals(sessionAdmin.role())) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-
-        if (request.customerId() == null) {
-            throw new CustomException(ErrorCode.CUSTOMER_ID_REQUIRED);
-        }
-
-        Admin admin = adminRepository.findById(sessionAdmin.adminId())
-                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
-
-        Customer customer = customerRepository.findById(request.customerId())
-                .orElseThrow(() -> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
-
-        product.decreaseStock(request.quantity());
-
-        Order order = new Order(totalPrice, request.quantity(), customer, product, admin, OrderStatus.PENDING);
-
-        Order savedOrder = orderRepository.save(order);
-
-        return OrderCreateResponse.from(savedOrder);
     }
 
     @Transactional

--- a/src/main/java/com/example/commercepilot/orders/service/OrderService.java
+++ b/src/main/java/com/example/commercepilot/orders/service/OrderService.java
@@ -15,7 +15,6 @@ import com.example.commercepilot.orders.dto.session.SessionCustomer;
 import com.example.commercepilot.orders.entity.Order;
 import com.example.commercepilot.orders.entity.OrderStatus;
 import com.example.commercepilot.orders.repository.OrderRepository;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +34,7 @@ public class OrderService {
         Product product = productRepository.findById(request.productId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        validateProduct(product, request.quantity());
+        validateProduct(product, request);
 
         long totalPrice = request.quantity() * product.getPrice();
 
@@ -66,7 +65,7 @@ public class OrderService {
         return OrderCreateResponse.from(savedOrder);
     }
 
-    private void validateProduct(Product product, int quantity) {
+    private void validateProduct(Product product, OrderCreateRequest request) {
         ProductStatus productStatus = product.getStatus();
 
         if (productStatus == ProductStatus.DISCONTINUED) {
@@ -75,7 +74,7 @@ public class OrderService {
         if (productStatus == ProductStatus.SOLD_OUT) {
             throw new CustomException(ErrorCode.PRODUCT_SOLD_OUT);
         }
-        if (stock < request.quantity()) {
+        if (product.getStock() < request.quantity()) {
             throw new CustomException(ErrorCode.INSUFFICIENT_STOCK);
         }
     }
@@ -85,17 +84,7 @@ public class OrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        OrderStatus status = order.getStatus();
-
-        if (status == OrderStatus.PENDING) {
-            status = OrderStatus.SHIPPING;
-        } else if (status == OrderStatus.SHIPPING) {
-            status = OrderStatus.DELIVERED;
-        } else {
-            throw new CustomException(ErrorCode.ORDER_STATUS_NOT_CHANGEABLE);
-        }
-
-        order.changeStatus(status);
+        order.proceed();
 
         return OrderUpdateResponse.from(order);
     }
@@ -111,7 +100,7 @@ public class OrderService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
         if (!order.getStatus().equals(OrderStatus.PENDING)) {
-            throw new CustomException(ErrorCode.ORDER_CANCLE_NOT_ALLOWED);
+            throw new CustomException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
         }
 
         Product product = order.getProduct();


### PR DESCRIPTION
## 💡 개요
- Order Entity 필드와 메서드 정리 및 컨트롤러-서비스-레포지토리 CUD 구현 완료.

## 🛠️ 작업 내용
- 주문 고유 번호를 UUID로 가지고, 사용자들에게 보기 편하도록 포맷팅(날짜-랜덤UUID) 적용.
- 관리자와 로그인을 한 고객을 대상으로, 주문 생성/수정/삭제를 진행할 수 있도록 세션 적용.
- 주문 생성과 취소 부분에서 재고 차감/복원을 단순 위임하면서 상품(Product) 엔티티에서 처리하도록 구현.
- 주문에 대한 처리를 진행할 때, 예외처리와 특정 조건에 분기할 수 있도록 구현.

## 💬 리뷰 포인트
- 관리자가 로그인한 세션은 sessionAdmin, 고객이 로그인한 세션은 sessionCustomer로 지정하면서 두 세션 모두 id(PK)와 role(역할)을 가질 수 있도록 했습니다. 역할은 CS 관리자만 대리 주문이 가능하다고 명시되어 있기에, 분기할 수 있도록 필드로 지정했습니다.
- 메서드명, 필드명이 현재 개발 중인 도메인과 일치하지 않다면 알려주세요.  


- Closes: #24 
