### PR TITLE
feat:상품 서비스 제외 모든 기능 구현,상품 조회/검색/재고 상태 자동 갱신 기능 추가

### DIFF
--- a/src/main/java/com/example/commercepilot/exception/ErrorCode.java
+++ b/src/main/java/com/example/commercepilot/exception/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.example.commercepilot.exception;
 
+import com.example.commercepilot.category.entity.Category;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -31,6 +32,10 @@ public enum ErrorCode {
     PRODUCT_SOLD_OUT(HttpStatus.BAD_REQUEST, "P002", "품절된 상품입니다."),
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "P003", "재고가 부족합니다."),
     INVALID_STOCK_AMOUNT(HttpStatus.BAD_REQUEST, "P004", "재고 증감 수량은 1 이상이어야 합니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P005", "해당 상품을 찾을 수 없습니다."),
+    INVALID_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "P006", "가격은 0 이상이어야 합니다."),
+    PRODUCT_NAME_BLANK(HttpStatus.BAD_REQUEST, "P007", "상품명은 공백일 수 없습니다."),
+
 
     // 고객 관련 에러 코드("CU###")
     CUSTOMER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CU001", "고객 ID는 필수입니다."),
@@ -50,7 +55,10 @@ public enum ErrorCode {
     // 주문 관련 에러 코드("O###")
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "해당 주문을 찾을 수 없습니다."),
     ORDER_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "O002", "취소할 수 없는 주문입니다."),
-    ORDER_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "O003", "변경할 수 없는 주문 상태입니다.");
+    ORDER_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "O003", "변경할 수 없는 주문 상태입니다."),
+
+    // 카테고리 관련 에러 코드("CA###")
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CA001", "해당 카테고리를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/commercepilot/exception/ErrorCode.java
+++ b/src/main/java/com/example/commercepilot/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     PRODUCT_DISCONTINUED(HttpStatus.BAD_REQUEST, "P001", "단종된 상품입니다."),
     PRODUCT_SOLD_OUT(HttpStatus.BAD_REQUEST, "P002", "품절된 상품입니다."),
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "P003", "재고가 부족합니다."),
+    INVALID_STOCK_AMOUNT(HttpStatus.BAD_REQUEST, "P004", "재고 증감 수량은 1 이상이어야 합니다."),
 
     // 고객 관련 에러 코드("CU###")
     CUSTOMER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CU001", "고객 ID는 필수입니다."),

--- a/src/main/java/com/example/commercepilot/product/controller/ProductController.java
+++ b/src/main/java/com/example/commercepilot/product/controller/ProductController.java
@@ -1,0 +1,62 @@
+package com.example.commercepilot.product.controller;
+
+import com.example.commercepilot.exception.ApiResponse;
+import com.example.commercepilot.product.dto.request.ProductCreateRequest;
+import com.example.commercepilot.product.dto.request.ProductSearchRequest;
+import com.example.commercepilot.product.dto.request.ProductUpdateRequest;
+import com.example.commercepilot.product.dto.response.ProductCreateResponse;
+import com.example.commercepilot.product.dto.response.ProductListResponse;
+import com.example.commercepilot.product.dto.response.ProductUpdateResponse;
+import com.example.commercepilot.product.service.ProductCommandService;
+import com.example.commercepilot.product.service.ProductQueryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+//- 카테고리 필터 (예: 전자기기, 패션/의류, 식품)
+public class ProductController {
+    private final ProductCommandService productCommandService;
+    private final ProductQueryService productQueryService;
+
+    @PostMapping // 상품 생성
+    public ResponseEntity<ApiResponse<ProductCreateResponse>> createProduct(
+            @SessionAttribute
+            @Valid @RequestBody ProductCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, productCommandService.createProduct(request)));
+    }
+
+    @PatchMapping("/{productId}") // 상품 수정 (상품명, 카테고리, 가격, 재고)
+    public ResponseEntity<ApiResponse<ProductUpdateResponse>> updateProduct(
+            @Valid @RequestBody ProductUpdateRequest request,
+            @PathVariable Long productId) {
+        return ResponseEntity.ok
+                (ApiResponse.success(HttpStatus.OK, productCommandService.updateProduct(request, productId)));
+    }
+
+    @GetMapping("/{productId}") // 상품 단건 조회
+    public ResponseEntity<ApiResponse<ProductListResponse>> getProduct(
+            @PathVariable Long productId) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, productQueryService.getProduct(productId)));
+    }
+
+    @GetMapping // 상품 전체 조회
+    public ResponseEntity<ApiResponse<Page<ProductListResponse>>> getProducts(
+            @Valid @ModelAttribute ProductSearchRequest request) {
+        return ResponseEntity.ok(
+                ApiResponse.success(HttpStatus.OK, productQueryService.getProducts(request)));
+    }
+
+    @DeleteMapping("/{productId}") // 상품 단건 삭제
+    public ResponseEntity<ApiResponse<Void>> deleteProduct(
+            @PathVariable Long productId) {
+        productCommandService.deleteProduct(productId);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
+    }
+}

--- a/src/main/java/com/example/commercepilot/product/controller/ProductController.java
+++ b/src/main/java/com/example/commercepilot/product/controller/ProductController.java
@@ -37,17 +37,17 @@ public class ProductController {
                 (ApiResponse.success(HttpStatus.OK, productCommandService.updateProduct(sessionAdmin, request, productId)));
     }
 
-    @GetMapping("/{productId}") // 상품 단건 조회
-    public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
+    @GetMapping("/{productId}") // 상품 상세 조회
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> getProductDetail(
             @PathVariable Long productId) {
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, productQueryService.getProduct(productId)));
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, productQueryService.getProductDetail(productId)));
     }
 
     @GetMapping // 상품 전체 조회
-    public ResponseEntity<ApiResponse<Page<ProductListResponse>>> getProducts(
+    public ResponseEntity<ApiResponse<Page<ProductListResponse>>> getProductList(
             @Valid @ModelAttribute ProductSearchRequest request) {
         return ResponseEntity.ok(
-                ApiResponse.success(HttpStatus.OK, productQueryService.getProducts(request)));
+                ApiResponse.success(HttpStatus.OK, productQueryService.getProductList(request)));
     }
 
     @DeleteMapping("/{productId}") // 상품 단건 삭제
@@ -64,7 +64,7 @@ public class ProductController {
             @PathVariable Long productId,
             @RequestBody StockChangeRequest request) {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK,
-                productCommandService.changeStock(sessionAdmin, productId, request.newStock())));
+                productCommandService.updateStock(sessionAdmin, productId, request.newStock())));
     }
 
     @PatchMapping("/{productId}/stock/increase") // 기존 재고 추가
@@ -90,8 +90,8 @@ public class ProductController {
             @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
             @PathVariable Long productId
     ) {
-        productCommandService.discontinueProduct(sessionAdmin, productId);
-        return ResponseEntity.noContent().build();
+        productCommandService.discontinuedProduct(sessionAdmin, productId);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
     }
 }
 

--- a/src/main/java/com/example/commercepilot/product/controller/ProductController.java
+++ b/src/main/java/com/example/commercepilot/product/controller/ProductController.java
@@ -28,7 +28,7 @@ public class ProductController {
                 .body(ApiResponse.success(HttpStatus.CREATED, productCommandService.createProduct(sessionAdmin, request)));
     }
 
-    @PatchMapping("/{productId}") // 상품 수정 (상품명, 카테고리, 가격, 재고)
+    @PatchMapping("/{productId}") // 상품 수정 (상품명, 카테고리, 가격)
     public ResponseEntity<ApiResponse<ProductUpdateResponse>> updateProduct(
             @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
             @Valid @RequestBody ProductUpdateRequest request,
@@ -86,11 +86,11 @@ public class ProductController {
     }
 
     @PatchMapping("/{productId}/status/discontinue") // 재고상태 단종으로 변경
-    public ResponseEntity<ApiResponse<Void>> discontinue(
+    public ResponseEntity<ApiResponse<Void>> discontinueProduct(
             @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
             @PathVariable Long productId
     ) {
-        productCommandService.discontinuedProduct(sessionAdmin, productId);
+        productCommandService.discontinueProduct(sessionAdmin, productId);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
     }
 }

--- a/src/main/java/com/example/commercepilot/product/controller/ProductController.java
+++ b/src/main/java/com/example/commercepilot/product/controller/ProductController.java
@@ -1,12 +1,8 @@
 package com.example.commercepilot.product.controller;
 
 import com.example.commercepilot.exception.ApiResponse;
-import com.example.commercepilot.product.dto.request.ProductCreateRequest;
-import com.example.commercepilot.product.dto.request.ProductSearchRequest;
-import com.example.commercepilot.product.dto.request.ProductUpdateRequest;
-import com.example.commercepilot.product.dto.response.ProductCreateResponse;
-import com.example.commercepilot.product.dto.response.ProductListResponse;
-import com.example.commercepilot.product.dto.response.ProductUpdateResponse;
+import com.example.commercepilot.product.dto.request.*;
+import com.example.commercepilot.product.dto.response.*;
 import com.example.commercepilot.product.service.ProductCommandService;
 import com.example.commercepilot.product.service.ProductQueryService;
 import jakarta.validation.Valid;
@@ -19,29 +15,30 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/products")
 @RequiredArgsConstructor
-//- 카테고리 필터 (예: 전자기기, 패션/의류, 식품)
+
 public class ProductController {
     private final ProductCommandService productCommandService;
     private final ProductQueryService productQueryService;
 
     @PostMapping // 상품 생성
     public ResponseEntity<ApiResponse<ProductCreateResponse>> createProduct(
-            @SessionAttribute
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
             @Valid @RequestBody ProductCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(HttpStatus.CREATED, productCommandService.createProduct(request)));
+                .body(ApiResponse.success(HttpStatus.CREATED, productCommandService.createProduct(sessionAdmin, request)));
     }
 
     @PatchMapping("/{productId}") // 상품 수정 (상품명, 카테고리, 가격, 재고)
     public ResponseEntity<ApiResponse<ProductUpdateResponse>> updateProduct(
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
             @Valid @RequestBody ProductUpdateRequest request,
             @PathVariable Long productId) {
         return ResponseEntity.ok
-                (ApiResponse.success(HttpStatus.OK, productCommandService.updateProduct(request, productId)));
+                (ApiResponse.success(HttpStatus.OK, productCommandService.updateProduct(sessionAdmin, request, productId)));
     }
 
     @GetMapping("/{productId}") // 상품 단건 조회
-    public ResponseEntity<ApiResponse<ProductListResponse>> getProduct(
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
             @PathVariable Long productId) {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, productQueryService.getProduct(productId)));
     }
@@ -55,8 +52,46 @@ public class ProductController {
 
     @DeleteMapping("/{productId}") // 상품 단건 삭제
     public ResponseEntity<ApiResponse<Void>> deleteProduct(
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
             @PathVariable Long productId) {
-        productCommandService.deleteProduct(productId);
+        productCommandService.deleteProduct(sessionAdmin, productId);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
     }
+
+    @PatchMapping("/{productId}/stock") // 재고 값 변경
+    public ResponseEntity<ApiResponse<StockChangeResponse>> changeStock(
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
+            @PathVariable Long productId,
+            @RequestBody StockChangeRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK,
+                productCommandService.changeStock(sessionAdmin, productId, request.newStock())));
+    }
+
+    @PatchMapping("/{productId}/stock/increase") // 기존 재고 추가
+    public ResponseEntity<ApiResponse<StockChangeResponse>> increaseStock(
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
+            @PathVariable Long productId,
+            @RequestBody StockAmountRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK,
+                productCommandService.increaseStock(sessionAdmin, productId, request.amount())));
+    }
+
+    @PatchMapping("/{productId}/stock/decrease") // 기존 재고 감소
+    public ResponseEntity<ApiResponse<StockChangeResponse>> decreaseStock(
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
+            @PathVariable Long productId,
+            @RequestBody StockAmountRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK,
+                productCommandService.decreaseStock(sessionAdmin, productId, request.amount())));
+    }
+
+    @PatchMapping("/{productId}/status/discontinue") // 재고상태 단종으로 변경
+    public ResponseEntity<ApiResponse<Void>> discontinue(
+            @SessionAttribute(name = "loginAdmin", required = false) SessionAdmin sessionAdmin,
+            @PathVariable Long productId
+    ) {
+        productCommandService.discontinueProduct(sessionAdmin, productId);
+        return ResponseEntity.noContent().build();
+    }
 }
+

--- a/src/main/java/com/example/commercepilot/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/ProductCreateRequest.java
@@ -1,0 +1,21 @@
+package com.example.commercepilot.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// 상품 등록 요청 시 입력 정보 "상품명, 카테고리, 가격, 재고, 상태"
+public record ProductCreateRequest(
+        @NotBlank(message = "상품명은 필수값입니다.")
+        @Size(max = 30, message = "30자 이내로 작성해주세요.")
+        String productName,
+        @NotBlank(message = "카테고리명은 필수값입니다.")
+        @Size(max = 20, message = "20자 이내로 작성해주세요.")
+        String category,
+        @NotBlank(message = "가격은 필수값입니다.")
+        Long price,
+        @NotBlank(message = "재고는 필수값입니다.")
+        int stock,
+        @NotBlank(message = "재고상태는 필수값입니다.")
+        String status
+) {
+}

--- a/src/main/java/com/example/commercepilot/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/ProductCreateRequest.java
@@ -1,21 +1,29 @@
 package com.example.commercepilot.product.dto.request;
 
+import com.example.commercepilot.product.entity.ProductStatus;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 // 상품 등록 요청 시 입력 정보 "상품명, 카테고리, 가격, 재고, 상태"
 public record ProductCreateRequest(
+
         @NotBlank(message = "상품명은 필수값입니다.")
-        @Size(max = 30, message = "30자 이내로 작성해주세요.")
+        @Size(min = 1, message = "상품명은 비어있을 수 없습니다.")
         String productName,
-        @NotBlank(message = "카테고리명은 필수값입니다.")
-        @Size(max = 20, message = "20자 이내로 작성해주세요.")
-        String category,
-        @NotBlank(message = "가격은 필수값입니다.")
+
+        @NotNull(message = "카테고리ID는 필수값입니다.")
+        Long categoryId,
+
+        @NotNull(message = "가격은 필수값입니다.")
+        @Min(value = 1, message = "가격은 1원 이상이어야 합니다.")
         Long price,
-        @NotBlank(message = "재고는 필수값입니다.")
+
+        @Min(value = 1, message = "재고는 1개 이상이어야 합니다.")
         int stock,
-        @NotBlank(message = "재고상태는 필수값입니다.")
-        String status
+
+        @NotNull(message = "재고상태는 필수값입니다.")
+        ProductStatus status
 ) {
 }

--- a/src/main/java/com/example/commercepilot/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/ProductSearchRequest.java
@@ -1,0 +1,34 @@
+package com.example.commercepilot.product.dto.request;
+
+import com.example.commercepilot.product.entity.ProductStatus;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProductSearchRequest {
+    // 검색키워드
+    private String keyword;
+
+    // 카테고리 필터
+    private Long CategoryId;
+
+    // 상태 필터
+    private ProductStatus productStatus;
+
+    // 페이지 번호(기본값: 1)
+    @Min( value = 1, message ="페이지 번호는 1 이상이어야 합니다.")
+    private int page = 1;
+
+    // 페이지당 개수(기본값: 10)
+    @Max(value = 100, message = "한번에 최대 100개까지만 조회할 수 있습니다.")
+    private int size = 10;
+
+    // 등록일을 기준으로 정렬
+    private String sortBy = "createdAt";
+
+    // 내림차순으로 정렬
+    private String sortDir = "desc";
+}

--- a/src/main/java/com/example/commercepilot/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/ProductSearchRequest.java
@@ -19,7 +19,7 @@ public class ProductSearchRequest {
     private ProductStatus productStatus;
 
     // 페이지 번호(기본값: 1)
-    @Min( value = 1, message ="페이지 번호는 1 이상이어야 합니다.")
+    @Min(value = 1, message ="페이지 번호는 1 이상이어야 합니다.")
     private int page = 1;
 
     // 페이지당 개수(기본값: 10)

--- a/src/main/java/com/example/commercepilot/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/ProductUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.example.commercepilot.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProductUpdateRequest(
+        // 수정 가능한 필드: "상품명, 카테고리, 가격" + 재고를 자동처리할지 여기서 처리할지 고민중
+        @NotBlank(message = "상품명은 필수값입니다.")
+        @Size(max = 30, message = "30자 이내로 작성해주세요.")
+        String productName,
+        @NotBlank(message = "카테고리명은 필수값입니다.")
+        String category,
+        @NotBlank(message = "가격은 필수값입니다.")
+        Long price
+) {
+}

--- a/src/main/java/com/example/commercepilot/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/ProductUpdateRequest.java
@@ -1,16 +1,17 @@
 package com.example.commercepilot.product.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 public record ProductUpdateRequest(
-        // 수정 가능한 필드: "상품명, 카테고리, 가격" + 재고를 자동처리할지 여기서 처리할지 고민중
-        @NotBlank(message = "상품명은 필수값입니다.")
-        @Size(max = 30, message = "30자 이내로 작성해주세요.")
+
+        @Size(min = 1, message = "상품명은 비어있을 수 없습니다.")
         String productName,
-        @NotBlank(message = "카테고리명은 필수값입니다.")
-        String category,
-        @NotBlank(message = "가격은 필수값입니다.")
+
+        // 카테고리 명은 카테고리파트에서 변경 가능, 상품파트에서는 그저 존재하는 다른 카테고리로 옮긴단 느낌
+        Long categoryId,
+
+        @Min(value = 1, message = "가격은 1원 이상이어야 합니다.")
         Long price
 ) {
 }

--- a/src/main/java/com/example/commercepilot/product/dto/request/SessionAdmin.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/SessionAdmin.java
@@ -1,0 +1,12 @@
+package com.example.commercepilot.product.dto.request;
+
+
+import com.example.commercepilot.admin.entity.AdminRole;
+import jakarta.validation.constraints.NotNull;
+
+public record SessionAdmin(
+        @NotNull(message = "관리자 ID는 필수입니다.")
+        Long adminId,
+        @NotNull(message = "관리자 역할은 필수입니다.")
+        AdminRole role) {
+}

--- a/src/main/java/com/example/commercepilot/product/dto/request/StockAmountRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/StockAmountRequest.java
@@ -1,0 +1,8 @@
+package com.example.commercepilot.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record StockAmountRequest(
+        @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
+        int amount
+) {}

--- a/src/main/java/com/example/commercepilot/product/dto/request/StockChangeRequest.java
+++ b/src/main/java/com/example/commercepilot/product/dto/request/StockChangeRequest.java
@@ -1,0 +1,9 @@
+package com.example.commercepilot.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record StockChangeRequest(
+        @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
+        int newStock
+) {
+}

--- a/src/main/java/com/example/commercepilot/product/dto/response/ProductCreateResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/ProductCreateResponse.java
@@ -1,0 +1,33 @@
+package com.example.commercepilot.product.dto.response;
+
+import com.example.commercepilot.product.entity.Product;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+// 고유 ID, 등록관리자명, 등록일 추가로 응답받음
+public record ProductCreateResponse(
+        Long id,
+        String productName,
+        String category,
+        Long price,
+        String adminName,
+        int stock,
+        String status,
+        LocalDateTime createdAt) {
+
+    public static ProductCreateResponse from(Product product) {
+        return ProductCreateResponse.builder()
+                .id(product.getId())
+                .adminName(product.getAdmin().getAdminName())
+                .productName(product.getProductName())
+                .category(product.getCategory().getName())
+                .price(product.getPrice())
+                .stock(product.getStock())
+                .status(product.getStatus().getLabel())
+                .createdAt(product.getCreatedAt())
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/commercepilot/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/ProductDetailResponse.java
@@ -1,0 +1,37 @@
+package com.example.commercepilot.product.dto.response;
+
+import com.example.commercepilot.product.entity.Product;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+// 특정 상품의 상세 정보를 조회합니다.
+// `상품명`, `카테고리`, `가격`, `재고`, `상태`, `등록일`,  `등록 관리자명`, `등록 관리자 이메일`
+// 존재하지 않는 ID 요청 시 에러를 반환합니다.
+@Builder
+public record ProductDetailResponse(
+        Long id,
+        String productName,
+        String category,
+        Long price,
+        int stock,
+        String status,
+        LocalDateTime createdAt,
+        String adminName,
+        String adminEmail) {
+
+    public static ProductDetailResponse from(Product product) {
+        return ProductDetailResponse.builder()
+                .id(product.getId())
+                .productName(product.getProductName())
+                .category(product.getCategory().getName())
+                .price(product.getPrice())
+                .stock(product.getStock())
+                .status(product.getStatus().getLabel())
+                .createdAt(product.getCreatedAt())
+                .adminName(product.getAdmin().getAdminName())
+                .adminEmail(product.getAdmin().getEmail())
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/commercepilot/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/ProductDetailResponse.java
@@ -1,5 +1,6 @@
 package com.example.commercepilot.product.dto.response;
 
+import com.example.commercepilot.admin.entity.Admin;
 import com.example.commercepilot.product.entity.Product;
 import lombok.Builder;
 
@@ -21,6 +22,10 @@ public record ProductDetailResponse(
         String adminEmail) {
 
     public static ProductDetailResponse from(Product product) {
+
+        // getAdmin() 중복 호출 피하기 위해 변수로 분리
+        Admin admin = product.getAdmin();
+
         return ProductDetailResponse.builder()
                 .id(product.getId())
                 .productName(product.getProductName())
@@ -29,8 +34,8 @@ public record ProductDetailResponse(
                 .stock(product.getStock())
                 .status(product.getStatus().getLabel())
                 .createdAt(product.getCreatedAt())
-                .adminName(product.getAdmin().getAdminName())
-                .adminEmail(product.getAdmin().getEmail())
+                .adminName(admin.getAdminName())
+                .adminEmail(admin.getEmail())
                 .build();
     }
 }

--- a/src/main/java/com/example/commercepilot/product/dto/response/ProductListResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/ProductListResponse.java
@@ -1,0 +1,31 @@
+package com.example.commercepilot.product.dto.response;
+
+import com.example.commercepilot.product.entity.Product;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+// 고유 식별자(ID), 상품명, 카테고리, 가격, 재고, 상태, 등록일, 등록 관리자명
+public record ProductListResponse(
+        Long id,
+        String productName,
+        String category,
+        Long price,
+        int stock,
+        String status,
+        LocalDateTime createdAt,
+        String adminName) {
+    public static ProductListResponse from(Product product) {
+        return ProductListResponse.builder()
+                .id(product.getId())
+                .productName(product.getProductName())
+                .category(product.getCategory().getName())
+                .price(product.getPrice())
+                .stock(product.getStock())
+                .status(product.getStatus().getLabel())
+                .createdAt(product.getCreatedAt())
+                .adminName(product.getAdmin().getAdminName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/commercepilot/product/dto/response/ProductUpdateResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/ProductUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.example.commercepilot.product.dto.response;
+
+import com.example.commercepilot.product.entity.Product;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ProductUpdateResponse(
+        Long id,
+        String productName,
+        String category,
+        Long price,
+        LocalDateTime createAt,
+        LocalDateTime modifiedAt
+) {
+    public static ProductUpdateResponse from(Product product) {
+        return new ProductUpdateResponse(
+                product.getId(),
+                product.getProductName(),
+                product.getCategory().getName(),
+                product.getPrice(),
+                product.getCreatedAt(),
+                product.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/commercepilot/product/dto/response/ProductUpdateResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/ProductUpdateResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 public record ProductUpdateResponse(
         Long id,
         String productName,
+        Long categoryId,
         String category,
         Long price,
         LocalDateTime createAt,
@@ -18,6 +19,7 @@ public record ProductUpdateResponse(
         return new ProductUpdateResponse(
                 product.getId(),
                 product.getProductName(),
+                product.getCategory().getId(),
                 product.getCategory().getName(),
                 product.getPrice(),
                 product.getCreatedAt(),

--- a/src/main/java/com/example/commercepilot/product/dto/response/ProductUpdateResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/ProductUpdateResponse.java
@@ -1,5 +1,6 @@
 package com.example.commercepilot.product.dto.response;
 
+import com.example.commercepilot.category.entity.Category;
 import com.example.commercepilot.product.entity.Product;
 import lombok.Builder;
 
@@ -16,14 +17,18 @@ public record ProductUpdateResponse(
         LocalDateTime modifiedAt
 ) {
     public static ProductUpdateResponse from(Product product) {
-        return new ProductUpdateResponse(
-                product.getId(),
-                product.getProductName(),
-                product.getCategory().getId(),
-                product.getCategory().getName(),
-                product.getPrice(),
-                product.getCreatedAt(),
-                product.getModifiedAt()
-        );
+
+        // getCategory() 중복 호출을 피하기 위해 변수 분리
+        Category cat = product.getCategory();
+
+        return  ProductUpdateResponse.builder()
+                .id(product.getId())
+                .productName(product.getProductName())
+                .categoryId(cat.getId())
+                .category(cat.getName())
+                .price(product.getPrice())
+                .createAt(product.getCreatedAt())
+                .modifiedAt(product.getModifiedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/commercepilot/product/dto/response/StockChangeResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/StockChangeResponse.java
@@ -1,0 +1,16 @@
+package com.example.commercepilot.product.dto.response;
+
+import com.example.commercepilot.product.entity.Product;
+import com.example.commercepilot.product.entity.ProductStatus;
+
+// 재고값 변경 응답 dto
+public record StockChangeResponse(
+        Long productId,
+        int stock,
+        ProductStatus status
+) {
+    public static StockChangeResponse from(Product product) {
+        return new StockChangeResponse(product.getId(), product.getStock(), product.getStatus());
+    }
+
+}

--- a/src/main/java/com/example/commercepilot/product/dto/response/StockChangeResponse.java
+++ b/src/main/java/com/example/commercepilot/product/dto/response/StockChangeResponse.java
@@ -2,15 +2,21 @@ package com.example.commercepilot.product.dto.response;
 
 import com.example.commercepilot.product.entity.Product;
 import com.example.commercepilot.product.entity.ProductStatus;
+import lombok.Builder;
 
+@Builder
 // 재고값 변경 응답 dto
 public record StockChangeResponse(
-        Long productId,
+        Long id,
         int stock,
         ProductStatus status
 ) {
     public static StockChangeResponse from(Product product) {
-        return new StockChangeResponse(product.getId(), product.getStock(), product.getStatus());
-    }
 
+        return StockChangeResponse.builder()
+                .id(product.getId())
+                .stock(product.getStock())
+                .status(product.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/com/example/commercepilot/product/entity/Product.java
+++ b/src/main/java/com/example/commercepilot/product/entity/Product.java
@@ -1,0 +1,102 @@
+package com.example.commercepilot.product.entity;
+
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.category.entity.Category;
+import com.example.commercepilot.config.BaseEntity;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
+
+@Getter
+@Entity
+@Table(name= "products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SoftDelete(columnName = "is_deleted")
+public class Product extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 고유 id
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String productName; // 상품명
+
+    @Column(nullable = false)
+    private Long price; // 가격
+
+    private int stock; // 재고
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProductStatus status; // 상태(판매중, 품절, 단종)
+
+    @ManyToOne(fetch = FetchType.LAZY,optional = false)
+    @JoinColumn(name = "admin_id",nullable = false)
+    private Admin admin; // 상품 관련 관리자 연관관계
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "category_id",nullable = false)
+    private Category category; // 상품 관련 카테고리 연관관계
+
+    public Product(String productName, Long price, int stock, ProductStatus status, Category category, Admin admin) {
+        this.productName = productName;
+        this.price = price;
+        this.stock = stock;
+        this.status = status;
+        this.category = category;
+        this.admin = admin;
+    }
+    // 수정 가능한 필드: "상품명, 카테고리, 가격, 재고"
+    public void updateProduct(String productName, Category category, Long price) {
+        this.productName = productName;
+        this.category = category;
+        this.price = price;
+    }
+
+    public void changeStock(int newstock) {
+        this.stock = newstock;
+        updateStatusByStock();
+    }
+    // 재고 추가 메서드
+    public void increaseStock(int amount) {
+        if (amount <= 0) {
+            throw new CustomException(ErrorCode.INVALID_STOCK_AMOUNT);
+        }
+            this.stock += amount;
+        updateStatusByStock();
+    }
+
+    // 재고 감소 메서드
+    public void decreaseStock(int amount) {
+        // 감소요청이 0보다 작거나 같을 경우 예외처리(증감수량은 1이상이어야해)
+        if (amount <= 0) {
+            throw new CustomException(ErrorCode.INVALID_STOCK_AMOUNT);
+        }
+        // 재고보다 감소 요청이 더 많을 경우 예외처리
+        if (this.stock - amount < 0) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_STOCK);
+        }
+            this.stock -= amount;
+        updateStatusByStock();
+    }
+
+    // 재고에 따른 상품상태 변화 메서드
+    private void updateStatusByStock() {
+
+        // 단종 상태인 경우, 상태 변경하지 않고 단종 상태를 유지
+        if (this.status == ProductStatus.DISCONTINUED) {
+            return;
+        }
+        // 재고가 0보다 작거나 같으면 품절
+        if(this.stock <= 0) {
+            this.status = ProductStatus.SOLD_OUT;
+        }
+        // 아니면 판매중
+        else {
+            this.status = ProductStatus.ON_SALE;
+        }
+    }
+
+}

--- a/src/main/java/com/example/commercepilot/product/entity/Product.java
+++ b/src/main/java/com/example/commercepilot/product/entity/Product.java
@@ -63,14 +63,14 @@ public class Product extends BaseEntity {
         this.price = updatePrice;
     }
 
-    public void updateStock(int newstock) {
+    public void updateStock(int newStock) {
         if (this.status == ProductStatus.DISCONTINUED) {
             throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
         }
-        if (newstock < 0) {
+        if (newStock < 0) {
             throw new CustomException(ErrorCode.INVALID_STOCK_AMOUNT);
         }
-        this.stock = newstock;
+        this.stock = newStock;
         updateStatusByStock();
     }
 
@@ -126,5 +126,26 @@ public class Product extends BaseEntity {
     public void disontinued() {
         this.status = ProductStatus.DISCONTINUED;
 
+    }
+
+    public void updateProduct(String productName, Long price, Category category) {
+
+        if (productName != null) {
+            if (productName.isBlank()) {
+                throw new CustomException(ErrorCode.PRODUCT_NAME_BLANK);
+            }
+            this.productName = productName;
+        }
+
+        if (category != null) {
+            this.category = category;
+        }
+
+        if (price != null) {
+            if (price < 0) {
+                throw new CustomException(ErrorCode.INVALID_PRODUCT_PRICE);
+            }
+            this.price = price;
+        }
     }
 }

--- a/src/main/java/com/example/commercepilot/product/entity/Product.java
+++ b/src/main/java/com/example/commercepilot/product/entity/Product.java
@@ -6,6 +6,7 @@ import com.example.commercepilot.config.BaseEntity;
 import com.example.commercepilot.exception.CustomException;
 import com.example.commercepilot.exception.ErrorCode;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,11 +14,12 @@ import org.hibernate.annotations.SoftDelete;
 
 @Getter
 @Entity
-@Table(name= "products")
+@Table(name = "products")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SoftDelete(columnName = "is_deleted")
 public class Product extends BaseEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 고유 id
 
     @Column(nullable = false, unique = true, length = 50)
@@ -32,12 +34,12 @@ public class Product extends BaseEntity {
     @Column(nullable = false)
     private ProductStatus status; // 상태(판매중, 품절, 단종)
 
-    @ManyToOne(fetch = FetchType.LAZY,optional = false)
-    @JoinColumn(name = "admin_id",nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "admin_id", nullable = false)
     private Admin admin; // 상품 관련 관리자 연관관계
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "category_id",nullable = false)
+    @JoinColumn(name = "category_id", nullable = false)
     private Category category; // 상품 관련 카테고리 연관관계
 
     public Product(String productName, Long price, int stock, ProductStatus status, Category category, Admin admin) {
@@ -48,6 +50,7 @@ public class Product extends BaseEntity {
         this.category = category;
         this.admin = admin;
     }
+
     // 수정 가능한 필드: "상품명, 카테고리, 가격, 재고"
     public void updateProduct(String productName, Category category, Long price) {
         this.productName = productName;
@@ -56,20 +59,33 @@ public class Product extends BaseEntity {
     }
 
     public void changeStock(int newstock) {
+        if (this.status == ProductStatus.DISCONTINUED) {
+            throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
+        }
+        if (newstock < 0) {
+            throw new CustomException(ErrorCode.INVALID_STOCK_AMOUNT);
+        }
         this.stock = newstock;
         updateStatusByStock();
     }
+
     // 재고 추가 메서드
     public void increaseStock(int amount) {
+        if (this.status == ProductStatus.DISCONTINUED) {
+            throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
+        }
         if (amount <= 0) {
             throw new CustomException(ErrorCode.INVALID_STOCK_AMOUNT);
         }
-            this.stock += amount;
+        this.stock += amount;
         updateStatusByStock();
     }
 
     // 재고 감소 메서드
     public void decreaseStock(int amount) {
+        if (this.status == ProductStatus.DISCONTINUED) {
+            throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
+        }
         // 감소요청이 0보다 작거나 같을 경우 예외처리(증감수량은 1이상이어야해)
         if (amount <= 0) {
             throw new CustomException(ErrorCode.INVALID_STOCK_AMOUNT);
@@ -78,7 +94,7 @@ public class Product extends BaseEntity {
         if (this.stock - amount < 0) {
             throw new CustomException(ErrorCode.INSUFFICIENT_STOCK);
         }
-            this.stock -= amount;
+        this.stock -= amount;
         updateStatusByStock();
     }
 
@@ -90,7 +106,7 @@ public class Product extends BaseEntity {
             return;
         }
         // 재고가 0보다 작거나 같으면 품절
-        if(this.stock <= 0) {
+        if (this.stock <= 0) {
             this.status = ProductStatus.SOLD_OUT;
         }
         // 아니면 판매중
@@ -99,4 +115,20 @@ public class Product extends BaseEntity {
         }
     }
 
+    public void updateProductName(String newProductName) {
+        this.productName = newProductName;
+    }
+
+    public void changeCategory(Category category) {
+        this.category = category;
+    }
+
+    public void changePrice(Long updatePrice) {
+        this.price = updatePrice;
+    }
+
+    public void disontinue() {
+        this.status = ProductStatus.DISCONTINUED;
+
+    }
 }

--- a/src/main/java/com/example/commercepilot/product/entity/Product.java
+++ b/src/main/java/com/example/commercepilot/product/entity/Product.java
@@ -6,7 +6,6 @@ import com.example.commercepilot.config.BaseEntity;
 import com.example.commercepilot.exception.CustomException;
 import com.example.commercepilot.exception.ErrorCode;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,14 +50,20 @@ public class Product extends BaseEntity {
         this.admin = admin;
     }
 
-    // 수정 가능한 필드: "상품명, 카테고리, 가격, 재고"
-    public void updateProduct(String productName, Category category, Long price) {
-        this.productName = productName;
-        this.category = category;
-        this.price = price;
+    // 수정 가능한 필드: "상품명, 카테고리, 가격"
+    public void updateProductName(String newProductName) {
+        this.productName = newProductName;
     }
 
-    public void changeStock(int newstock) {
+    public void updateCategory(Category category) {
+        this.category = category;
+    }
+
+    public void updatePrice(Long updatePrice) {
+        this.price = updatePrice;
+    }
+
+    public void updateStock(int newstock) {
         if (this.status == ProductStatus.DISCONTINUED) {
             throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
         }
@@ -71,6 +76,8 @@ public class Product extends BaseEntity {
 
     // 재고 추가 메서드
     public void increaseStock(int amount) {
+
+        // 단종처리상태인 상품 재고 추가 불가
         if (this.status == ProductStatus.DISCONTINUED) {
             throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
         }
@@ -86,7 +93,7 @@ public class Product extends BaseEntity {
         if (this.status == ProductStatus.DISCONTINUED) {
             throw new CustomException(ErrorCode.PRODUCT_DISCONTINUED);
         }
-        // 감소요청이 0보다 작거나 같을 경우 예외처리(증감수량은 1이상이어야해)
+        // 감소요청이 0보다 작거나 같을 경우 예외처리
         if (amount <= 0) {
             throw new CustomException(ErrorCode.INVALID_STOCK_AMOUNT);
         }
@@ -115,19 +122,8 @@ public class Product extends BaseEntity {
         }
     }
 
-    public void updateProductName(String newProductName) {
-        this.productName = newProductName;
-    }
-
-    public void changeCategory(Category category) {
-        this.category = category;
-    }
-
-    public void changePrice(Long updatePrice) {
-        this.price = updatePrice;
-    }
-
-    public void disontinue() {
+    // 단종상태 처리
+    public void disontinued() {
         this.status = ProductStatus.DISCONTINUED;
 
     }

--- a/src/main/java/com/example/commercepilot/product/entity/ProductStatus.java
+++ b/src/main/java/com/example/commercepilot/product/entity/ProductStatus.java
@@ -1,0 +1,15 @@
+package com.example.commercepilot.product.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ProductStatus {
+    ON_SALE("판매중"), // 판매중
+    SOLD_OUT("품절"), // 품절
+    DISCONTINUED ("단종"); // 단종
+
+    private final String label;
+    ProductStatus(String label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/com/example/commercepilot/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/commercepilot/product/repository/ProductRepository.java
@@ -1,7 +1,30 @@
 package com.example.commercepilot.product.repository;
 
 import com.example.commercepilot.product.entity.Product;
+import com.example.commercepilot.product.entity.ProductStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product,Long> {
+    @Query("""
+select p
+from Product p
+/*
+   키워드 검색
+   카테고리 필터
+   상태 필터
+*/
+where (:keyword is null or :keyword = '' or p.productName like %:keyword%)
+  and (:categoryId is null or p.category.id = :categoryId)
+  and (:status is null or p.status = :status)
+""")
+    Page<Product> search(
+            @Param("keyword") String keyword,
+            @Param("categoryId") Long categoryId,
+            @Param("status") ProductStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/commercepilot/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/commercepilot/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.example.commercepilot.product.repository;
+
+import com.example.commercepilot.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product,Long> {
+}

--- a/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
@@ -1,65 +1,218 @@
 package com.example.commercepilot.product.service;
 
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.entity.AdminRole;
+import com.example.commercepilot.admin.repository.AdminRepository;
+import com.example.commercepilot.category.entity.Category;
+import com.example.commercepilot.category.repository.CategoryRepository;
 import com.example.commercepilot.exception.CustomException;
 import com.example.commercepilot.exception.ErrorCode;
 import com.example.commercepilot.product.dto.request.ProductCreateRequest;
 import com.example.commercepilot.product.dto.request.ProductUpdateRequest;
+import com.example.commercepilot.product.dto.request.SessionAdmin;
 import com.example.commercepilot.product.dto.response.ProductCreateResponse;
-import com.example.commercepilot.product.dto.response.ProductListResponse;
 import com.example.commercepilot.product.dto.response.ProductUpdateResponse;
+import com.example.commercepilot.product.dto.response.StockChangeResponse;
 import com.example.commercepilot.product.entity.Product;
 import com.example.commercepilot.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-@Transactional
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 //쓰기전용
 public class ProductCommandService {
 
+    private final CategoryRepository categoryRepository;
+    private final AdminRepository adminRepository;
     private final ProductRepository productRepository;
 
-    public ProductCreateResponse createProduct(ProductCreateRequest request) {
+    @Transactional
+    public ProductCreateResponse createProduct(SessionAdmin sessionAdmin, ProductCreateRequest request) {
+
+        // 로그인 인증
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 관리자 존재 검증
+        Admin admin = adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        // 카테고리 조회
+        Category category = categoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
         Product product = new Product(
-                request.getProductName(),
-                request.getPrice(),
-                request.getStock(),
-                request.getStatus(),
-                category
+                request.productName(),
+                request.price(),
+                request.stock(),
+                request.status(),
+                category,
+                admin
         );
 
         Product savedProduct = productRepository.save(product);
 
-        return new ProductCreateResponse(
-                savedProduct.getId(),
-                savedProduct.getProductName(),
-                savedProduct.getPrice(),
-                savedProduct.getStock(),
-                savedProduct.getStatus(),
-                savedProduct.getCreatedAt()
-        );
+        return ProductCreateResponse.from(savedProduct);
     }
 
     @Transactional
-    public ProductUpdateResponse updateProduct(ProductUpdateRequest request, Long productId) {
-        throw new CustomException(ErrorCode.
-    }
 
-    public ProductListResponse getOne(Long productId) {
+    public ProductUpdateResponse updateProduct(SessionAdmin sessionAdmin, ProductUpdateRequest request, Long productId) {
 
-    }
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
+        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
 
-    public List<ProductListResponse> getAll() {
+        // 존재하는 상품인지 체크
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        String newProductName = request.productName();
+        if (newProductName != null) { // 이름이 '들어온 경우'에만 검사/수정
+            if (newProductName.isBlank()) { // 들어왔는데 공백이면 = 잘못된 요청
+                throw new CustomException(ErrorCode.PRODUCT_NAME_BLANK);
+            }
+            product.updateProductName(newProductName);
+        }
+
+        Long changeCategoryId = request.categoryId();
+        if (changeCategoryId != null) {
+            Category category = categoryRepository.findById(changeCategoryId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
+            product.changeCategory(category);
+        }
+
+        Long updatePrice = request.price();
+        if (updatePrice != null) {
+            if (updatePrice < 0) {
+                throw new CustomException(ErrorCode.INVALID_PRODUCT_PRICE);
+            }
+            product.changePrice(updatePrice);
+        }
+
+        return ProductUpdateResponse.from(product);
 
     }
 
     @Transactional
-    public void deleteProduct(Long productId) {
+    public void deleteProduct(SessionAdmin sessionAdmin, Long productId) {
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        productRepository.deleteById(productId);
+    }
+
+    @Transactional
+    public StockChangeResponse changeStock(SessionAdmin sessionAdmin, Long productId, int newStock) {
+        // 로그인 인증
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 관리자 존재 검증
+        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.changeStock(newStock);
+
+        return StockChangeResponse.from(product);
+    }
+
+    @Transactional
+    public StockChangeResponse increaseStock(SessionAdmin sessionAdmin, Long productId, int amount) {
+        // 로그인 인증
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 관리자 존재 검증
+        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.increaseStock(amount);
+
+        return StockChangeResponse.from(product);
+    }
+
+    @Transactional
+    public StockChangeResponse decreaseStock(SessionAdmin sessionAdmin, Long productId, int amount) {
+
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.decreaseStock(amount);
+
+        return StockChangeResponse.from(product);
+    }
+
+    @Transactional
+    public void discontinueProduct(SessionAdmin sessionAdmin, Long productId) {
+
+        if (sessionAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.disontinue();
+
 
     }
 }
-}
+
+
+

--- a/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
@@ -29,24 +29,37 @@ public class ProductCommandService {
     private final AdminRepository adminRepository;
     private final ProductRepository productRepository;
 
-    public ProductCreateResponse createProduct(SessionAdmin sessionAdmin, ProductCreateRequest request) {
-
-        // 로그인 인증
+    // 관리자 권한 및 존재 여부 검증
+    private Admin validateAdmin(SessionAdmin sessionAdmin) {
         if (sessionAdmin == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
-
-        // 관리자 존재 검증
         Admin admin = adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
                 () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
+        return admin;
+    }
 
-        // 카테고리 조회
-        Category category = categoryRepository.findById(request.categoryId())
+    // 삭제/수정 대상 상품 존재 검증
+    private Product validateProduct(Long productId) {
+        return productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    // 요청 카테고리 유효성 검증
+    private Category validateCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    public ProductCreateResponse createProduct(SessionAdmin sessionAdmin, ProductCreateRequest request) {
+
+        Admin admin = validateAdmin(sessionAdmin);
+
+        Category category = validateCategory(request.categoryId());
 
         Product product = new Product(
                 request.productName(),
@@ -64,80 +77,33 @@ public class ProductCommandService {
 
     public ProductUpdateResponse updateProduct(SessionAdmin sessionAdmin, ProductUpdateRequest request, Long productId) {
 
-        if (sessionAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        validateAdmin(sessionAdmin);
+
+        Product product = validateProduct(productId);
+
+        Category category = null;
+        if (request.categoryId() != null) {
+            category = validateCategory(request.categoryId());
         }
-        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
-                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
-
-        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
-
-        // 존재하는 상품인지 체크
-        Product product = productRepository.findById(productId).orElseThrow(
-                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
-
-        String newProductName = request.productName();
-        if (newProductName != null) { // 이름이 '들어온 경우'에만 검사/수정
-            if (newProductName.isBlank()) { // 들어왔는데 공백이면 = 잘못된 요청
-                throw new CustomException(ErrorCode.PRODUCT_NAME_BLANK);
-            }
-            product.updateProductName(newProductName);
-        }
-
-        Long changeCategoryId = request.categoryId();
-        if (changeCategoryId != null) {
-            Category category = categoryRepository.findById(changeCategoryId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
-
-            product.updateCategory(category);
-        }
-
-        Long updatePrice = request.price();
-        if (updatePrice != null) {
-            if (updatePrice < 0) {
-                throw new CustomException(ErrorCode.INVALID_PRODUCT_PRICE);
-            }
-            product.updatePrice(updatePrice);
-        }
+        product.updateProduct(request.productName(), request.price(), category);
 
         return ProductUpdateResponse.from(product);
-
     }
 
     public void deleteProduct(SessionAdmin sessionAdmin, Long productId) {
-        if (sessionAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
-                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
+        validateAdmin(sessionAdmin);
 
-        productRepository.findById(productId).orElseThrow(
-                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        validateProduct(productId);
 
         productRepository.deleteById(productId);
     }
 
     public StockChangeResponse updateStock(SessionAdmin sessionAdmin, Long productId, int newStock) {
-        // 로그인 인증
-        if (sessionAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
 
-        // 관리자 존재 검증
-        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
-                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+        validateAdmin(sessionAdmin);
 
-        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
-        Product product = productRepository.findById(productId).orElseThrow(
-                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        Product product = validateProduct(productId);
 
         product.updateStock(newStock);
 
@@ -146,18 +112,9 @@ public class ProductCommandService {
 
     public StockChangeResponse increaseStock(SessionAdmin sessionAdmin, Long productId, int amount) {
 
-        if (sessionAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
+        validateAdmin(sessionAdmin);
 
-        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
-                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
-
-        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
-        Product product = productRepository.findById(productId).orElseThrow(
-                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        Product product = validateProduct(productId);
 
         product.increaseStock(amount);
 
@@ -166,38 +123,19 @@ public class ProductCommandService {
 
     public StockChangeResponse decreaseStock(SessionAdmin sessionAdmin, Long productId, int amount) {
 
-        if (sessionAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
+        validateAdmin(sessionAdmin);
 
-        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
-                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
-
-        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
-        Product product = productRepository.findById(productId).orElseThrow(
-                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        Product product = validateProduct(productId);
 
         product.decreaseStock(amount);
 
         return StockChangeResponse.from(product);
     }
 
-    public void discontinuedProduct(SessionAdmin sessionAdmin, Long productId) {
+    public void discontinueProduct(SessionAdmin sessionAdmin, Long productId) {
+        validateAdmin(sessionAdmin);
 
-        if (sessionAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
-                () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
-
-        if (sessionAdmin.role() != AdminRole.OPERATION_ADMIN && sessionAdmin.role() != AdminRole.SUPER_ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
-        Product product = productRepository.findById(productId).orElseThrow(
-                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        Product product = validateProduct(productId);
 
         product.disontinued();
 

--- a/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
@@ -1,0 +1,65 @@
+package com.example.commercepilot.product.service;
+
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
+import com.example.commercepilot.product.dto.request.ProductCreateRequest;
+import com.example.commercepilot.product.dto.request.ProductUpdateRequest;
+import com.example.commercepilot.product.dto.response.ProductCreateResponse;
+import com.example.commercepilot.product.dto.response.ProductListResponse;
+import com.example.commercepilot.product.dto.response.ProductUpdateResponse;
+import com.example.commercepilot.product.entity.Product;
+import com.example.commercepilot.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+@Transactional
+@Service
+@RequiredArgsConstructor
+//쓰기전용
+public class ProductCommandService {
+
+    private final ProductRepository productRepository;
+
+    public ProductCreateResponse createProduct(ProductCreateRequest request) {
+        Product product = new Product(
+                request.getProductName(),
+                request.getPrice(),
+                request.getStock(),
+                request.getStatus(),
+                category
+        );
+
+        Product savedProduct = productRepository.save(product);
+
+        return new ProductCreateResponse(
+                savedProduct.getId(),
+                savedProduct.getProductName(),
+                savedProduct.getPrice(),
+                savedProduct.getStock(),
+                savedProduct.getStatus(),
+                savedProduct.getCreatedAt()
+        );
+    }
+
+    @Transactional
+    public ProductUpdateResponse updateProduct(ProductUpdateRequest request, Long productId) {
+        throw new CustomException(ErrorCode.
+    }
+
+    public ProductListResponse getOne(Long productId) {
+
+    }
+
+
+    public List<ProductListResponse> getAll() {
+
+    }
+
+    @Transactional
+    public void deleteProduct(Long productId) {
+
+    }
+}
+}

--- a/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/commercepilot/product/service/ProductCommandService.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional(readOnly = true)
+@Transactional
 @Service
 @RequiredArgsConstructor
 //쓰기전용
@@ -29,7 +29,6 @@ public class ProductCommandService {
     private final AdminRepository adminRepository;
     private final ProductRepository productRepository;
 
-    @Transactional
     public ProductCreateResponse createProduct(SessionAdmin sessionAdmin, ProductCreateRequest request) {
 
         // 로그인 인증
@@ -63,8 +62,6 @@ public class ProductCommandService {
         return ProductCreateResponse.from(savedProduct);
     }
 
-    @Transactional
-
     public ProductUpdateResponse updateProduct(SessionAdmin sessionAdmin, ProductUpdateRequest request, Long productId) {
 
         if (sessionAdmin == null) {
@@ -94,7 +91,7 @@ public class ProductCommandService {
             Category category = categoryRepository.findById(changeCategoryId)
                     .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
 
-            product.changeCategory(category);
+            product.updateCategory(category);
         }
 
         Long updatePrice = request.price();
@@ -102,14 +99,13 @@ public class ProductCommandService {
             if (updatePrice < 0) {
                 throw new CustomException(ErrorCode.INVALID_PRODUCT_PRICE);
             }
-            product.changePrice(updatePrice);
+            product.updatePrice(updatePrice);
         }
 
         return ProductUpdateResponse.from(product);
 
     }
 
-    @Transactional
     public void deleteProduct(SessionAdmin sessionAdmin, Long productId) {
         if (sessionAdmin == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
@@ -127,8 +123,7 @@ public class ProductCommandService {
         productRepository.deleteById(productId);
     }
 
-    @Transactional
-    public StockChangeResponse changeStock(SessionAdmin sessionAdmin, Long productId, int newStock) {
+    public StockChangeResponse updateStock(SessionAdmin sessionAdmin, Long productId, int newStock) {
         // 로그인 인증
         if (sessionAdmin == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
@@ -144,19 +139,17 @@ public class ProductCommandService {
         Product product = productRepository.findById(productId).orElseThrow(
                 () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        product.changeStock(newStock);
+        product.updateStock(newStock);
 
         return StockChangeResponse.from(product);
     }
 
-    @Transactional
     public StockChangeResponse increaseStock(SessionAdmin sessionAdmin, Long productId, int amount) {
-        // 로그인 인증
+
         if (sessionAdmin == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 관리자 존재 검증
         adminRepository.findById(sessionAdmin.adminId()).orElseThrow(
                 () -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
@@ -171,7 +164,6 @@ public class ProductCommandService {
         return StockChangeResponse.from(product);
     }
 
-    @Transactional
     public StockChangeResponse decreaseStock(SessionAdmin sessionAdmin, Long productId, int amount) {
 
         if (sessionAdmin == null) {
@@ -192,8 +184,7 @@ public class ProductCommandService {
         return StockChangeResponse.from(product);
     }
 
-    @Transactional
-    public void discontinueProduct(SessionAdmin sessionAdmin, Long productId) {
+    public void discontinuedProduct(SessionAdmin sessionAdmin, Long productId) {
 
         if (sessionAdmin == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
@@ -208,7 +199,7 @@ public class ProductCommandService {
         Product product = productRepository.findById(productId).orElseThrow(
                 () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        product.disontinue();
+        product.disontinued();
 
 
     }

--- a/src/main/java/com/example/commercepilot/product/service/ProductQueryService.java
+++ b/src/main/java/com/example/commercepilot/product/service/ProductQueryService.java
@@ -1,10 +1,17 @@
 package com.example.commercepilot.product.service;
 
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
 import com.example.commercepilot.product.dto.request.ProductSearchRequest;
+import com.example.commercepilot.product.dto.response.ProductDetailResponse;
 import com.example.commercepilot.product.dto.response.ProductListResponse;
+import com.example.commercepilot.product.entity.Product;
 import com.example.commercepilot.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,11 +21,35 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductQueryService {
     private final ProductRepository productRepository;
 
+    public Page<ProductListResponse> getProductList(ProductSearchRequest request) {
 
-    public Page<ProductListResponse> getProducts(ProductSearchRequest request) {
+        int page = request.getPage() - 1; // 사용자 요청은 1페이지이지만 Spring Pageable은 0부터 시작하기 떄문에 -1
+        int size = request.getSize(); // 한 페이지에 보여줄 상품 수
 
+        Sort.Direction direction; // 정렬 방향 변수
+
+        // 사용자가 asc라고 보냈는지 확인 (IgnoreCase통해 대소문자 무시)
+        if ("asc".equalsIgnoreCase(request.getSortDir())) {
+            direction = Sort.Direction.ASC;
+        } else {
+            direction = Sort.Direction.DESC;
+        }
+        // Pageable 생성
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, request.getSortBy()));
+
+        return productRepository.search(
+                request.getKeyword(), // 검색 키워드 (상품명)
+                request.getCategoryId(), // 카테고리 필터
+                request.getProductStatus(), // 상태 필터
+                pageable // 페이징
+        ).map(ProductListResponse::from);
     }
 
-    public ProductListResponse getProduct(Long productId) {
+
+    public ProductDetailResponse getProductDetail(Long productId) {
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        return ProductDetailResponse.from(product);
+
     }
 }

--- a/src/main/java/com/example/commercepilot/product/service/ProductQueryService.java
+++ b/src/main/java/com/example/commercepilot/product/service/ProductQueryService.java
@@ -1,0 +1,24 @@
+package com.example.commercepilot.product.service;
+
+import com.example.commercepilot.product.dto.request.ProductSearchRequest;
+import com.example.commercepilot.product.dto.response.ProductListResponse;
+import com.example.commercepilot.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class ProductQueryService {
+    private final ProductRepository productRepository;
+
+
+    public Page<ProductListResponse> getProducts(ProductSearchRequest request) {
+
+    }
+
+    public ProductListResponse getProduct(Long productId) {
+    }
+}

--- a/src/main/java/com/example/commercepilot/product/service/ProductQueryService.java
+++ b/src/main/java/com/example/commercepilot/product/service/ProductQueryService.java
@@ -45,11 +45,9 @@ public class ProductQueryService {
         ).map(ProductListResponse::from);
     }
 
-
     public ProductDetailResponse getProductDetail(Long productId) {
         Product product = productRepository.findById(productId).orElseThrow(
                 () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
         return ProductDetailResponse.from(product);
-
     }
 }


### PR DESCRIPTION
## 💡 개요
- 상품 Service 제외 모든 기능 구성 (service 클래스 내일 구현하겠습니다..)
- category 클래스도 구성 못함(내일 하도록 하겠습니다)
- ProductSearchRequest 생성(검색 키워드, 페이지번호, 페이지당 개수, 정렬기준(등록일), 정렬순서(desc) 내림차순, 카테고리 필터, 상태 필터) 담음

## 🛠️ 작업 내용
- [ ]  ProductSearchRequest 생성(검색 키워드, 페이지번호, 페이지당 개수, 정렬기준(등록일), 정렬순서(desc) 내림차순, 카테고리 필터, 상태 필터) 담음
- [ ] ProductController 구성
- [ ] ProductStatus(상품 재고상태) Enum으로 구현
- [ ] request , response 패키지 나누고 구현
- [ ] service 읽기, 쓰기 따로 구현 (아직 로직 구현하지않음)
- [ ] 상품 공통 Errorcode 생성 ( INVALID_STOCK_AMOUNT(HttpStatus.BAD_REQUEST, "P004", "재고 증감 수량은 1 이상이어야 합니다.")

## 💬 리뷰 포인트
- service클래스를 제외한 다른 클래스들과 기능들이 제대로 구현되어 있는가?
- 좀 더 추가하면 좋을만한 게 무엇이 있을까?
- 빠진 부분은 없는가?