### PR TITLE
feat: 관리자 내 정보 조회/수정 및 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/example/commercepilot/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/example/commercepilot/admin/controller/AdminAuthController.java
@@ -1,11 +1,17 @@
 package com.example.commercepilot.admin.controller;
 
+import com.example.commercepilot.admin.config.SessionConst;
 import com.example.commercepilot.admin.dto.request.AdminLoginRequest;
+import com.example.commercepilot.admin.dto.request.AdminPasswordChangeRequest;
 import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
+import com.example.commercepilot.admin.dto.request.AdminUpdateRequest;
 import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
+import com.example.commercepilot.admin.dto.session.LoginAdmin;
 import com.example.commercepilot.admin.service.AdminAuthService;
 import com.example.commercepilot.admin.service.AdminCommandService;
 import com.example.commercepilot.exception.ApiResponse;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +41,53 @@ public class AdminAuthController {
     @PostMapping("/logout")
     public ApiResponse<Void> logout(HttpSession session) {
         adminAuthService.logout(session);
+        return ApiResponse.success(HttpStatus.OK);
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<AdminSignupResponse> getMyProfile(HttpSession session) {
+
+        LoginAdmin loginAdmin = (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return ApiResponse.success(HttpStatus.OK,
+                adminCommandService.getMyProfile(loginAdmin.adminId()));
+    }
+
+    @PatchMapping("/me")
+    public ApiResponse<Void> updateMyProfile(
+            @Valid @RequestBody AdminUpdateRequest request,
+            HttpSession session
+    ) {
+
+        LoginAdmin loginAdmin = (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        adminCommandService.updateMyProfile(loginAdmin.adminId(), request);
+
+        return ApiResponse.success(HttpStatus.OK);
+    }
+
+    @PatchMapping("/me/password")
+    public ApiResponse<Void> changePassword(
+            @Valid @RequestBody AdminPasswordChangeRequest request,
+            HttpSession session
+    ) {
+
+        LoginAdmin loginAdmin = (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        adminCommandService.changePassword(loginAdmin.adminId(), request);
+
         return ApiResponse.success(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminPasswordChangeRequest.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminPasswordChangeRequest.java
@@ -1,0 +1,14 @@
+package com.example.commercepilot.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminPasswordChangeRequest(
+
+        @NotBlank(message = "현재 비밀번호는 필수입니다.")
+        String currentPassword,
+
+        @Size(min = 8, message = "새 비밀번호는 최소 8자 이상이어야 합니다.")
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        String newPassword
+) {}

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminUpdateRequest.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.example.commercepilot.admin.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record AdminUpdateRequest(
+
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email,
+
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식은 010-XXXX-XXXX 입니다.")
+        @NotBlank(message = "전화번호는 필수입니다.")
+        String callNumber
+) {}

--- a/src/main/java/com/example/commercepilot/admin/entity/Admin.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/Admin.java
@@ -70,4 +70,8 @@ public class Admin {
     void preUpdate() {
         this.modifiedAt = LocalDateTime.now();
     }
+
+    public void changeStatus(AdminStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/example/commercepilot/admin/entity/Admin.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/Admin.java
@@ -74,4 +74,14 @@ public class Admin {
     public void changeStatus(AdminStatus status) {
         this.status = status;
     }
+
+    public void updateProfile(String name, String email, String callNumber) {
+        this.adminName = name;
+        this.email = email;
+        this.callNumber = callNumber;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
@@ -3,6 +3,7 @@ package com.example.commercepilot.admin.service;
 import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
 import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
 import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.entity.AdminStatus;
 import com.example.commercepilot.admin.repository.AdminRepository;
 import com.example.commercepilot.config.PasswordEncoder;
 import com.example.commercepilot.exception.CustomException;
@@ -37,5 +38,31 @@ public class AdminCommandService {
 
         Admin saved = adminRepository.save(admin);
         return AdminSignupResponse.from(saved);
+    }
+
+    @Transactional
+    public void approve(Long adminId) {
+
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (admin.getStatus() != AdminStatus.PENDING) {
+            throw new CustomException(ErrorCode.ADMIN_LOGIN_NOT_ACTIVE);
+        }
+
+        admin.changeStatus(AdminStatus.ACTIVE);
+    }
+
+    @Transactional
+    public void reject(Long adminId) {
+
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (admin.getStatus() != AdminStatus.PENDING) {
+            throw new CustomException(ErrorCode.ADMIN_LOGIN_NOT_ACTIVE);
+        }
+
+        admin.changeStatus(AdminStatus.REJECTED);
     }
 }

--- a/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
@@ -1,6 +1,8 @@
 package com.example.commercepilot.admin.service;
 
+import com.example.commercepilot.admin.dto.request.AdminPasswordChangeRequest;
 import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
+import com.example.commercepilot.admin.dto.request.AdminUpdateRequest;
 import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
 import com.example.commercepilot.admin.entity.Admin;
 import com.example.commercepilot.admin.entity.AdminStatus;
@@ -64,5 +66,36 @@ public class AdminCommandService {
         }
 
         admin.changeStatus(AdminStatus.REJECTED);
+    }
+
+    @Transactional(readOnly = true)
+    public AdminSignupResponse getMyProfile(Long adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        return AdminSignupResponse.from(admin);
+    }
+
+    @Transactional
+    public void updateMyProfile(Long adminId, AdminUpdateRequest request) {
+
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        admin.updateProfile(request.name(), request.email(), request.callNumber());
+    }
+
+    @Transactional
+    public void changePassword(Long adminId, AdminPasswordChangeRequest request) {
+
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.currentPassword(), admin.getPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
+        }
+
+        String encoded = passwordEncoder.encode(request.newPassword());
+        admin.changePassword(encoded);
     }
 }


### PR DESCRIPTION
## 💡 개요
- 로그인된 관리자 기준으로 내 프로필 조회/수정 및 비밀번호 변경 기능을 추가했습니다.

## 🛠️ 작업 내용
### DTO
- AdminUpdateRequest 추가 (이름/이메일/전화번호 Validation 포함)
- AdminPasswordChangeRequest 추가 (현재/새 비밀번호 Validation 포함)

### Service
- 내 프로필 조회 로직 추가 (getMyProfile)
- 내 프로필 수정 로직 추가 (updateMyProfile)
- 비밀번호 변경 로직 추가 (changePassword)
  - 현재 비밀번호 검증 후 새 비밀번호 암호화 저장

### Entity
- Admin 엔티티에 프로필 수정 메서드 추가 (updateProfile)
- Admin 엔티티에 비밀번호 변경 메서드 추가 (changePassword)

### Controller(API)
- GET /admins/me 추가 (내 프로필 조회)
- PATCH /admins/me 추가 (내 프로필 수정)
- PATCH /admins/me/password 추가 (비밀번호 변경)

## API 요약
- GET /admins/me
- PATCH /admins/me
- PATCH /admins/me/password

## 📷 스크린샷 (UI가 변경된 경우)
- 없음 (API 작업)

## 💬 리뷰 포인트
- 세션 기반 인증 처리 방식(session에서 LoginAdmin 조회 후 UNAUTHORIZED 처리)이 팀 컨벤션과 맞는지 확인 부탁드립니다.
- 프로필 수정(이메일 변경 포함) 시 이메일 중복 검증을 추가로 적용할지 의견 부탁드립니다.
- 비밀번호 변경 시 에러코드(PASSWORD_MISMATCH) 및 Validation 규칙이 요구사항과 일치하는지 확인 부탁드립니다.

- Closes: # (관련 이슈 번호)