### PR TITLE
feat: 관리자 목록/상세 조회 API 구현 / 검색,정렬,필터,페이징 지원

### DIFF
--- a/src/main/java/com/example/commercepilot/admin/config/SessionConst.java
+++ b/src/main/java/com/example/commercepilot/admin/config/SessionConst.java
@@ -4,4 +4,5 @@ public final class SessionConst {
     private SessionConst() {}
 
     public static final String LOGIN_ADMIN = "LOGIN_ADMIN";
+    public static final String LOGIN_SUPER_ADMIN = "LOGIN_SUPER_ADMIN";
 }

--- a/src/main/java/com/example/commercepilot/admin/controller/AdminManagementController.java
+++ b/src/main/java/com/example/commercepilot/admin/controller/AdminManagementController.java
@@ -1,0 +1,59 @@
+package com.example.commercepilot.admin.controller;
+
+import com.example.commercepilot.admin.config.SessionConst;
+import com.example.commercepilot.admin.dto.request.AdminSearchCondition;
+import com.example.commercepilot.admin.dto.response.AdminDetailResponse;
+import com.example.commercepilot.admin.dto.response.AdminListResponse;
+import com.example.commercepilot.admin.dto.session.LoginAdmin;
+import com.example.commercepilot.admin.entity.AdminRole;
+import com.example.commercepilot.admin.service.AdminQueryService;
+import com.example.commercepilot.exception.ApiResponse;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admins")
+public class AdminManagementController {
+
+    private final AdminQueryService adminQueryService;
+
+    @GetMapping
+    public ApiResponse<Page<AdminListResponse>> searchAdmins(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) AdminRole role,
+            @RequestParam(required = false) com.example.commercepilot.admin.entity.AdminStatus status,
+            Pageable pageable,
+            HttpSession session
+    ) {
+        requireSuperAdmin(session);
+
+        AdminSearchCondition condition = new AdminSearchCondition(keyword, role, status);
+        return ApiResponse.success(HttpStatus.OK, adminQueryService.search(condition, pageable));
+    }
+
+    @GetMapping("/{adminId}")
+    public ApiResponse<AdminDetailResponse> getAdminDetail(
+            @PathVariable Long adminId,
+            HttpSession session
+    ) {
+        requireSuperAdmin(session);
+        return ApiResponse.success(HttpStatus.OK, adminQueryService.getDetail(adminId));
+    }
+
+    private void requireSuperAdmin(HttpSession session) {
+        // TODO: SuperAdmin 세션 로그인 구현되면 아래 키로 체크 가능
+        Object superAdmin = session.getAttribute("LOGIN_SUPER_ADMIN");
+        if (superAdmin != null) return;
+
+        LoginAdmin loginAdmin = (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+        if (loginAdmin == null) throw new CustomException(ErrorCode.UNAUTHORIZED);
+        if (loginAdmin.role() != AdminRole.SUPER_ADMIN) throw new CustomException(ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/example/commercepilot/admin/controller/AdminManagementController.java
+++ b/src/main/java/com/example/commercepilot/admin/controller/AdminManagementController.java
@@ -6,6 +6,7 @@ import com.example.commercepilot.admin.dto.response.AdminDetailResponse;
 import com.example.commercepilot.admin.dto.response.AdminListResponse;
 import com.example.commercepilot.admin.dto.session.LoginAdmin;
 import com.example.commercepilot.admin.entity.AdminRole;
+import com.example.commercepilot.admin.entity.AdminStatus;
 import com.example.commercepilot.admin.service.AdminQueryService;
 import com.example.commercepilot.exception.ApiResponse;
 import com.example.commercepilot.exception.CustomException;
@@ -26,15 +27,11 @@ public class AdminManagementController {
 
     @GetMapping
     public ApiResponse<Page<AdminListResponse>> searchAdmins(
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) AdminRole role,
-            @RequestParam(required = false) com.example.commercepilot.admin.entity.AdminStatus status,
+            @ModelAttribute AdminSearchCondition condition,
             Pageable pageable,
             HttpSession session
     ) {
         requireSuperAdmin(session);
-
-        AdminSearchCondition condition = new AdminSearchCondition(keyword, role, status);
         return ApiResponse.success(HttpStatus.OK, adminQueryService.search(condition, pageable));
     }
 
@@ -49,7 +46,7 @@ public class AdminManagementController {
 
     private void requireSuperAdmin(HttpSession session) {
         // TODO: SuperAdmin 세션 로그인 구현되면 아래 키로 체크 가능
-        Object superAdmin = session.getAttribute("LOGIN_SUPER_ADMIN");
+        Object superAdmin = session.getAttribute(SessionConst.LOGIN_SUPER_ADMIN);
         if (superAdmin != null) return;
 
         LoginAdmin loginAdmin = (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminSearchCondition.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminSearchCondition.java
@@ -1,0 +1,10 @@
+package com.example.commercepilot.admin.dto.request;
+
+import com.example.commercepilot.admin.entity.AdminRole;
+import com.example.commercepilot.admin.entity.AdminStatus;
+
+public record AdminSearchCondition(
+        String keyword,     // name/email
+        AdminRole role,
+        AdminStatus status
+) {}

--- a/src/main/java/com/example/commercepilot/admin/dto/response/AdminDetailResponse.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/response/AdminDetailResponse.java
@@ -1,0 +1,31 @@
+package com.example.commercepilot.admin.dto.response;
+
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.entity.AdminRole;
+import com.example.commercepilot.admin.entity.AdminStatus;
+
+import java.time.LocalDateTime;
+
+public record AdminDetailResponse(
+        Long id,
+        String name,
+        String email,
+        String callNumber,
+        AdminRole role,
+        AdminStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static AdminDetailResponse from(Admin admin) {
+        return new AdminDetailResponse(
+                admin.getId(),
+                admin.getAdminName(),
+                admin.getEmail(),
+                admin.getCallNumber(),
+                admin.getRole(),
+                admin.getStatus(),
+                admin.getCreatedAt(),
+                admin.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/commercepilot/admin/dto/response/AdminListResponse.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/response/AdminListResponse.java
@@ -1,0 +1,29 @@
+package com.example.commercepilot.admin.dto.response;
+
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.entity.AdminRole;
+import com.example.commercepilot.admin.entity.AdminStatus;
+
+import java.time.LocalDateTime;
+
+public record AdminListResponse(
+        Long id,
+        String name,
+        String email,
+        String callNumber,
+        AdminRole role,
+        AdminStatus status,
+        LocalDateTime createdAt
+) {
+    public static AdminListResponse from(Admin admin) {
+        return new AdminListResponse(
+                admin.getId(),
+                admin.getAdminName(),
+                admin.getEmail(),
+                admin.getCallNumber(),
+                admin.getRole(),
+                admin.getStatus(),
+                admin.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/commercepilot/admin/repository/AdminRepository.java
+++ b/src/main/java/com/example/commercepilot/admin/repository/AdminRepository.java
@@ -2,10 +2,10 @@ package com.example.commercepilot.admin.repository;
 
 import com.example.commercepilot.admin.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import java.util.Optional;
 
-public interface AdminRepository extends JpaRepository<Admin, Long> {
+public interface AdminRepository extends JpaRepository<Admin, Long>, JpaSpecificationExecutor<Admin> {
     boolean existsByEmail(String email);
     Optional<Admin> findByEmail(String email);
 }

--- a/src/main/java/com/example/commercepilot/admin/repository/AdminSpecifications.java
+++ b/src/main/java/com/example/commercepilot/admin/repository/AdminSpecifications.java
@@ -1,0 +1,30 @@
+package com.example.commercepilot.admin.repository;
+
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.entity.AdminRole;
+import com.example.commercepilot.admin.entity.AdminStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class AdminSpecifications {
+
+    private AdminSpecifications() {}
+
+    public static Specification<Admin> keyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) return null;
+
+        return (root, query, cb) -> cb.or(
+                cb.like(cb.lower(root.get("adminName")), "%" + keyword.toLowerCase() + "%"),
+                cb.like(cb.lower(root.get("email")), "%" + keyword.toLowerCase() + "%")
+        );
+    }
+
+    public static Specification<Admin> role(AdminRole role) {
+        if (role == null) return null;
+        return (root, query, cb) -> cb.equal(root.get("role"), role);
+    }
+
+    public static Specification<Admin> status(AdminStatus status) {
+        if (status == null) return null;
+        return (root, query, cb) -> cb.equal(root.get("status"), status);
+    }
+}

--- a/src/main/java/com/example/commercepilot/admin/service/AdminQueryService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminQueryService.java
@@ -1,0 +1,40 @@
+package com.example.commercepilot.admin.service;
+
+import com.example.commercepilot.admin.dto.request.AdminSearchCondition;
+import com.example.commercepilot.admin.dto.response.AdminDetailResponse;
+import com.example.commercepilot.admin.dto.response.AdminListResponse;
+import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.repository.AdminRepository;
+import com.example.commercepilot.admin.repository.AdminSpecifications;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminQueryService {
+
+    private final AdminRepository adminRepository;
+
+    @Transactional(readOnly = true)
+    public Page<AdminListResponse> search(AdminSearchCondition condition, Pageable pageable) {
+
+        Specification<Admin> spec = Specification.where(AdminSpecifications.keyword(condition.keyword()))
+                .and(AdminSpecifications.role(condition.role()))
+                .and(AdminSpecifications.status(condition.status()));
+
+        return adminRepository.findAll(spec, pageable).map(AdminListResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public AdminDetailResponse getDetail(Long adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+        return AdminDetailResponse.from(admin);
+    }
+}

--- a/src/main/java/com/example/commercepilot/admin/service/AdminQueryService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminQueryService.java
@@ -17,11 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminQueryService {
 
     private final AdminRepository adminRepository;
 
-    @Transactional(readOnly = true)
     public Page<AdminListResponse> search(AdminSearchCondition condition, Pageable pageable) {
 
         Specification<Admin> spec = Specification.where(AdminSpecifications.keyword(condition.keyword()))
@@ -31,7 +31,6 @@ public class AdminQueryService {
         return adminRepository.findAll(spec, pageable).map(AdminListResponse::from);
     }
 
-    @Transactional(readOnly = true)
     public AdminDetailResponse getDetail(Long adminId) {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));


### PR DESCRIPTION
## 💡 개요
- 관리자 관리 기능 중 조회(Query) 파트인 관리자 목록 조회 + 관리자 상세 조회 API를 구현했습니다.
- 목록 조회는 검색(이름/이메일), 정렬, 역할/상태 필터, 페이징을 지원합니다.
- 조회 API는 SuperAdmin 권한(또는 임시 SUPER_ADMIN role) 기준으로 접근 제한을 적용했습니다.

## 🛠️ 작업 내용
-  관리자 목록 조회 API 구현: GET /admins
- 검색(keyword: name/email), 역할(role) 필터, 상태(status) 필터 지원
- Pageable 기반 정렬/페이징 지원
- 관리자 상세 조회 API 구현: GET /admins/{adminId}
- Query 로직 분리(AdminQueryService) 및 Specification 기반 동적 검색 구현
- 조회 응답 DTO 분리(목록/상세) 및 변환 로직(from) 추가
- 관리자 조회 권한 가드 로직 추가(세션 기반)

## 📷 스크린샷 (UI가 변경된 경우)
- (API 작업)

## 💬 리뷰 포인트
- Specification 기반 검색 조건 구성 방식이 적절한지 확인 부탁드립니다.
권한 체크(requireSuperAdmin)에서 LOGIN_SUPER_ADMIN 세션이 아직 없어서, 임시로 LOGIN_ADMIN 세션의 role이 SUPER_ADMIN인 경우도 허용하도록 처리했습니다. (SuperAdmin 로그인 구현 후 LOGIN_SUPER_ADMIN 기준으로 정리 예정)

- Closes: # (이슈 번호를 적으면, PR 머지 시 이슈가 자동 종료됩니다)
