### PR TITLE
feat: 관리자 수정·역할·상태 변경 및 삭제 API 구현 (관리자 관리 write 기능)

### DIFF
--- a/src/main/java/com/example/commercepilot/admin/controller/AdminManagementController.java
+++ b/src/main/java/com/example/commercepilot/admin/controller/AdminManagementController.java
@@ -1,17 +1,22 @@
 package com.example.commercepilot.admin.controller;
 
 import com.example.commercepilot.admin.config.SessionConst;
+import com.example.commercepilot.admin.dto.request.AdminModifyRequest;
+import com.example.commercepilot.admin.dto.request.AdminRoleChangeRequest;
 import com.example.commercepilot.admin.dto.request.AdminSearchCondition;
+import com.example.commercepilot.admin.dto.request.AdminStatusChangeRequest;
 import com.example.commercepilot.admin.dto.response.AdminDetailResponse;
 import com.example.commercepilot.admin.dto.response.AdminListResponse;
 import com.example.commercepilot.admin.dto.session.LoginAdmin;
 import com.example.commercepilot.admin.entity.AdminRole;
 import com.example.commercepilot.admin.entity.AdminStatus;
+import com.example.commercepilot.admin.service.AdminCommandService;
 import com.example.commercepilot.admin.service.AdminQueryService;
 import com.example.commercepilot.exception.ApiResponse;
 import com.example.commercepilot.exception.CustomException;
 import com.example.commercepilot.exception.ErrorCode;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminManagementController {
 
     private final AdminQueryService adminQueryService;
+    private final AdminCommandService adminCommandService;
 
     @GetMapping
     public ApiResponse<Page<AdminListResponse>> searchAdmins(
@@ -52,5 +58,48 @@ public class AdminManagementController {
         LoginAdmin loginAdmin = (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
         if (loginAdmin == null) throw new CustomException(ErrorCode.UNAUTHORIZED);
         if (loginAdmin.role() != AdminRole.SUPER_ADMIN) throw new CustomException(ErrorCode.ACCESS_DENIED);
+    }
+
+    @PatchMapping("/{adminId}")
+    public ApiResponse<Void> updateAdmin(
+            @PathVariable Long adminId,
+            @Valid @RequestBody AdminModifyRequest request,
+            HttpSession session
+    ) {
+        requireSuperAdmin(session);
+        adminCommandService.updateAdmin(adminId, request);
+        return ApiResponse.success(HttpStatus.OK);
+    }
+
+    @PatchMapping("/{adminId}/role")
+    public ApiResponse<Void> changeRole(
+            @PathVariable Long adminId,
+            @Valid @RequestBody AdminRoleChangeRequest request,
+            HttpSession session
+    ) {
+        requireSuperAdmin(session);
+        adminCommandService.changeRole(adminId, request.role());
+        return ApiResponse.success(HttpStatus.OK);
+    }
+
+    @PatchMapping("/{adminId}/status")
+    public ApiResponse<Void> changeStatus(
+            @PathVariable Long adminId,
+            @Valid @RequestBody AdminStatusChangeRequest request,
+            HttpSession session
+    ) {
+        requireSuperAdmin(session);
+        adminCommandService.changeStatus(adminId, request.status());
+        return ApiResponse.success(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{adminId}")
+    public ApiResponse<Void> deleteAdmin(
+            @PathVariable Long adminId,
+            HttpSession session
+    ) {
+        requireSuperAdmin(session);
+        adminCommandService.deleteAdmin(adminId);
+        return ApiResponse.success(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminModifyRequest.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminModifyRequest.java
@@ -1,0 +1,18 @@
+package com.example.commercepilot.admin.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record AdminModifyRequest(
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email,
+
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식은 010-XXXX-XXXX 입니다.")
+        @NotBlank(message = "전화번호는 필수입니다.")
+        String callNumber
+) {}

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminRoleChangeRequest.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminRoleChangeRequest.java
@@ -1,0 +1,9 @@
+package com.example.commercepilot.admin.dto.request;
+
+import com.example.commercepilot.admin.entity.AdminRole;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminRoleChangeRequest(
+        @NotNull(message = "역할은 필수입니다.")
+        AdminRole role
+) {}

--- a/src/main/java/com/example/commercepilot/admin/dto/request/AdminStatusChangeRequest.java
+++ b/src/main/java/com/example/commercepilot/admin/dto/request/AdminStatusChangeRequest.java
@@ -1,0 +1,9 @@
+package com.example.commercepilot.admin.dto.request;
+
+import com.example.commercepilot.admin.entity.AdminStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminStatusChangeRequest(
+        @NotNull(message = "상태는 필수입니다.")
+        AdminStatus status
+) {}

--- a/src/main/java/com/example/commercepilot/admin/entity/Admin.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/Admin.java
@@ -115,4 +115,7 @@ public class Admin {
         String encoded = passwordEncoder.encode(newPassword);
         this.changePassword(encoded);
     }
+    public void changeRole(AdminRole role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/example/commercepilot/admin/entity/Admin.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/Admin.java
@@ -118,4 +118,8 @@ public class Admin {
     public void changeRole(AdminRole role) {
         this.role = role;
     }
+
+    public void delete() {
+        this.status = AdminStatus.DELETED;
+    }
 }

--- a/src/main/java/com/example/commercepilot/admin/entity/AdminStatus.java
+++ b/src/main/java/com/example/commercepilot/admin/entity/AdminStatus.java
@@ -5,5 +5,6 @@ public enum AdminStatus {
     INACTIVE,
     SUSPENDED,
     PENDING,
-    REJECTED
+    REJECTED,
+    DELETED
 }

--- a/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
@@ -1,10 +1,12 @@
 package com.example.commercepilot.admin.service;
 
+import com.example.commercepilot.admin.dto.request.AdminModifyRequest;     // ✅ 추가
 import com.example.commercepilot.admin.dto.request.AdminPasswordChangeRequest;
 import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
 import com.example.commercepilot.admin.dto.request.AdminUpdateRequest;
 import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
 import com.example.commercepilot.admin.entity.Admin;
+import com.example.commercepilot.admin.entity.AdminRole;                 // ✅ 추가
 import com.example.commercepilot.admin.entity.AdminStatus;
 import com.example.commercepilot.admin.repository.AdminRepository;
 import com.example.commercepilot.config.PasswordEncoder;
@@ -49,7 +51,6 @@ public class AdminCommandService {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        // NOTE: PENDING이 아닌 경우에 대한 전용 ErrorCode가 있으면 더 적절함 (예: ADMIN_NOT_PENDING)
         if (admin.getStatus() != AdminStatus.PENDING) {
             throw new CustomException(ErrorCode.ADMIN_LOGIN_NOT_ACTIVE);
         }
@@ -63,7 +64,6 @@ public class AdminCommandService {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        // NOTE: PENDING이 아닌 경우에 대한 전용 ErrorCode가 있으면 더 적절함 (예: ADMIN_NOT_PENDING)
         if (admin.getStatus() != AdminStatus.PENDING) {
             throw new CustomException(ErrorCode.ADMIN_LOGIN_NOT_ACTIVE);
         }
@@ -106,7 +106,6 @@ public class AdminCommandService {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        // 이메일 중복 검증(권장)
         if (!admin.getEmail().equals(request.email()) && adminRepository.existsByEmail(request.email())) {
             throw new CustomException(ErrorCode.ADMIN_EMAIL_DUPLICATED);
         }

--- a/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
@@ -100,4 +100,41 @@ public class AdminCommandService {
                 request.newPasswordConfirm()
         );
     }
+
+    @Transactional
+    public void updateAdmin(Long adminId, AdminModifyRequest request) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        // 이메일 중복 검증(권장)
+        if (!admin.getEmail().equals(request.email()) && adminRepository.existsByEmail(request.email())) {
+            throw new CustomException(ErrorCode.ADMIN_EMAIL_DUPLICATED);
+        }
+
+        admin.updateProfile(request.name(), request.email(), request.callNumber());
+    }
+
+    @Transactional
+    public void changeRole(Long adminId, AdminRole role) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        admin.changeRole(role);
+    }
+
+    @Transactional
+    public void changeStatus(Long adminId, AdminStatus status) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        admin.changeStatus(status);
+    }
+
+    @Transactional
+    public void deleteAdmin(Long adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        adminRepository.delete(admin);
+    }
 }

--- a/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
+++ b/src/main/java/com/example/commercepilot/admin/service/AdminCommandService.java
@@ -1,12 +1,12 @@
 package com.example.commercepilot.admin.service;
 
-import com.example.commercepilot.admin.dto.request.AdminModifyRequest;     // ✅ 추가
+import com.example.commercepilot.admin.dto.request.AdminModifyRequest;
 import com.example.commercepilot.admin.dto.request.AdminPasswordChangeRequest;
 import com.example.commercepilot.admin.dto.request.AdminSignupRequest;
 import com.example.commercepilot.admin.dto.request.AdminUpdateRequest;
 import com.example.commercepilot.admin.dto.response.AdminSignupResponse;
 import com.example.commercepilot.admin.entity.Admin;
-import com.example.commercepilot.admin.entity.AdminRole;                 // ✅ 추가
+import com.example.commercepilot.admin.entity.AdminRole;
 import com.example.commercepilot.admin.entity.AdminStatus;
 import com.example.commercepilot.admin.repository.AdminRepository;
 import com.example.commercepilot.config.PasswordEncoder;
@@ -106,7 +106,8 @@ public class AdminCommandService {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        if (!admin.getEmail().equals(request.email()) && adminRepository.existsByEmail(request.email())) {
+        if (!admin.getEmail().equals(request.email())
+                && adminRepository.existsByEmail(request.email())) {
             throw new CustomException(ErrorCode.ADMIN_EMAIL_DUPLICATED);
         }
 
@@ -134,6 +135,6 @@ public class AdminCommandService {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        adminRepository.delete(admin);
+        admin.delete(); // status를 DELETED로 변경하는 소프트 삭제
     }
 }


### PR DESCRIPTION
## 💡 개요
- 관리자 관리 기능 중 Command 영역(쓰기)을 구현했습니다.
SuperAdmin 권한을 가진 사용자만 다른 관리자 정보를 수정/변경/삭제할 수 있도록 제한했습니다.
관리자 기본 정보 수정, 역할 변경, 상태 변경, 삭제 기능을 추가했습니다.

## 🛠️ 작업 내용
- 관리자 정보 수정 API 구현
   - PATCH /admins/{adminId}
    - 수정 가능: 이름, 이메일, 전화번호
    - 이메일 변경 시 중복 검증 로직 추가
 
- 관리자 역할 변경 API 구현
    - PATCH /admins/{adminId}/role

- 관리자 상태 변경 API 구현
    - PATCH /admins/{adminId}/status

- 관리자 삭제 API 구현
   - DELETE /admins/{adminId}

- AdminCommandService에 관련 비즈니스 로직 추가
- Admin 엔티티에 역할/상태 변경 메서드 추가
- 관리자 관리 API 접근 시 SuperAdmin 권한 체크 로직 적용


## 💬 리뷰 포인트
- 관리자 수정 시 이메일 변경에 대해 중복 검증 로직을 추가했습니다.
(기존 이메일과 동일한 경우는 통과하도록 처리)
- 역할/상태 변경은 단순 setter가 아닌 엔티티 메서드(changeRole, changeStatus)를 통해 처리했습니다. (도메인 로직 캡슐화를 고려한 구조)
- 현재 SuperAdmin 권한 체크는:
LOGIN_SUPER_ADMIN 세션 존재 여부 확인
또는 LOGIN_ADMIN의 role이 SUPER_ADMIN인 경우 허용 
구조로 구현되어 있습니다.
(추후 SuperAdmin 로그인 기능이 완성되면 세션 키 기준으로 정리 예정)


- Closes: # (이슈 번호를 적으면, PR 머지 시 이슈가 자동 종료됩니다)
