### PR TITLE
fix: 카테고리 복원 기능 및 주문 취소 기능의 결함 수정

### DIFF
--- a/src/main/java/com/example/commercepilot/category/entity/Category.java
+++ b/src/main/java/com/example/commercepilot/category/entity/Category.java
@@ -31,6 +31,9 @@ public class Category extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
+    @Column(name = "parent_id", insertable = false, updatable = false)
+    private Long parentId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Category parent;

--- a/src/main/java/com/example/commercepilot/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/commercepilot/category/repository/CategoryRepository.java
@@ -25,5 +25,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query(value = "SELECT * FROM category WHERE id = :id AND is_deleted = true", nativeQuery = true)
     Optional<Category> findDeletedById(@Param("id") Long id);
 
+    @Query(value = "SELECT * FROM category WHERE id = :id", nativeQuery = true)
+    Optional<Category> findByIdIgnoreDeleted(@Param("id") Long parentId);
+
     boolean existsByName(String name);
 }

--- a/src/main/java/com/example/commercepilot/category/service/CategoryService.java
+++ b/src/main/java/com/example/commercepilot/category/service/CategoryService.java
@@ -65,6 +65,16 @@ public class CategoryService {
     public void restore(Long categoryId) {
         Category category = categoryRepository.findDeletedById(categoryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        if (category.getParentId() != null) {
+            Category parentCategory = categoryRepository.findByIdIgnoreDeleted(category.getParentId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
+            if (parentCategory.isDeleted()) {
+                throw new CustomException(ErrorCode.CATEGORY_PARENT_DELETED);
+            }
+        }
+
         category.restore();
     }
 

--- a/src/main/java/com/example/commercepilot/exception/ErrorCode.java
+++ b/src/main/java/com/example/commercepilot/exception/ErrorCode.java
@@ -60,7 +60,8 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CA001", "해당 카테고리는 존재하지 않습니다."),
     SELF_REFERENCE_CATEGORY(HttpStatus.BAD_REQUEST, "CA002", "자신을 부모 카테고리로 가질 수 없습니다."),
     CIRCULAR_CATEGORY_REFERENCE(HttpStatus.BAD_REQUEST, "CA003", "자식이 부모가 되는 참조를 만들 수 없습니다."),
-    DUPLICATE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "CA004", "해당 카테고리명은 이미 존재합니다.");
+    DUPLICATE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "CA004", "해당 카테고리명은 이미 존재합니다."),
+    CATEGORY_PARENT_DELETED(HttpStatus.CONFLICT, "CA005", "부모 카테고리가 삭제된 상태입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/commercepilot/orders/service/OrderService.java
+++ b/src/main/java/com/example/commercepilot/orders/service/OrderService.java
@@ -85,13 +85,15 @@ public class OrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        Long customerId = order.getCustomer().getId();
+        if (loginCustomer != null) {
+            Long customerId = order.getCustomer().getId();
 
-        if (!loginCustomer.customerId().equals(customerId)) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
+            if (!loginCustomer.customerId().equals(customerId)) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
         }
 
-        resolveSession(loginAdmin, loginCustomer, customerId);
+        resolveSession(loginAdmin, loginCustomer, order.getCustomer().getId());
 
         if (!order.getStatus().equals(OrderStatus.PENDING)) {
             throw new CustomException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);


### PR DESCRIPTION
## 💡 개요
**카테고리**
- 기존: 부모-자식 카테고리가 삭제된 상황에서, 자식 카테고리를 우선적으로 복원하는 경우, 자식 카테고리가 부모 카테고리 레벨로 승격하게 되는 문제 발생
- 수정: 자식 카테고리를 우선적으로 복원하려는 경우, 해당 카테고리의 부모 카테고리가 삭제된 상태인지 검증하고 예외를 던지도록 설계

**주문**
- 기존: 주문을 취소할 때, 관리자가 대리 주문하는 케이스에서 loginCustomer가 Null이 할당된 상태로 값을 찾으려 했기에 NPE가 발생 
- 수정: 고객이 직접 주문을 삭제하는 케이스에서만, 본인 주문인지 확인하는 부분으로 검증 부분을 추가


## 💬 리뷰 포인트
- 로직의 문제점이 있는가?
- 요구사항을 준수하면서 확장성을 고려한 것인가?
- 또 다른 검증의 예외나 예외에 대한 처리가 제대로 이뤄졌는가?


- Closes: #50 
