### PR TITLE
fix:삭제된 카테고리를 조회하는 로직에서 발생하는 문제 해결

### DIFF
--- a/src/main/java/com/example/commercepilot/category/controller/CategoryController.java
+++ b/src/main/java/com/example/commercepilot/category/controller/CategoryController.java
@@ -63,8 +63,7 @@ public class CategoryController {
 
     @GetMapping("/deleted")
     public ResponseEntity<ApiResponse<List<CategoryDeleteResponse>>> getDeletedCategories(
-            @SessionAttribute(name = LOGIN_ADMIN, required = false) com.example.commercepilot.admin.dto.session.LoginAdmin loginAdmin,
-            @RequestParam(name = "status") HttpStatus status) {
+            @SessionAttribute(name = LOGIN_ADMIN, required = false) LoginAdmin loginAdmin) {
 
         if (loginAdmin == null) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);


### PR DESCRIPTION
## 💡 개요
- 삭제된 카테고리를 조회하는 과정에서 컨트롤러의 잘못된 매개변수를 받는 문제를 해결했다. 

## 🛠️ 작업 내용
- HttpStatus 상태값을 받는 매개변수를 제거했다.

## 💬 리뷰 포인트
- 삭제된 카테고리가 제대로 조회가 되는가?

- Closes: #65 
