### PR TITLE
fix: 카테고리 조회 기능의 N+1 문제와 영속성 전이, 동시성 이슈(비관적인 락 채택) 해결

### DIFF
--- a/src/main/java/com/example/commercepilot/category/entity/Category.java
+++ b/src/main/java/com/example/commercepilot/category/entity/Category.java
@@ -38,7 +38,7 @@ public class Category extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private Category parent;
 
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "parent", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<Category> children = new ArrayList<>();
 
     public Category(String name, Category parent) {

--- a/src/main/java/com/example/commercepilot/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/commercepilot/category/repository/CategoryRepository.java
@@ -69,7 +69,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
                         """, nativeQuery = true)
     List<Long> findAllDescendantIds(@Param("rootId") Long rootId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE Category c SET c.isDeleted = true, c.deletedAt = :now WHERE c.id IN :ids")
     void softDeleteAllByIds(@Param("ids") List<Long> ids, @Param("now") LocalDateTime now);
 

--- a/src/main/java/com/example/commercepilot/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/commercepilot/category/repository/CategoryRepository.java
@@ -1,12 +1,16 @@
 package com.example.commercepilot.category.repository;
 
 import com.example.commercepilot.category.entity.Category;
+import com.example.commercepilot.exception.CustomException;
+import com.example.commercepilot.exception.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,8 +20,16 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
             countQuery = "SELECT COUNT(c) FROM Category c")
     Page<Category> findAllWithParent(Pageable pageable);
 
-    @Query(value = "SELECT c FROM Category c LEFT JOIN FETCH c.children WHERE c.id = :id")
-    Optional<Category> findByIdWithChildren(@Param("id") Long id);
+    @Query(value = "SELECT c FROM Category c LEFT JOIN FETCH c.parent WHERE c.id = :id")
+    Optional<Category> findByIdWithParent(@Param("id") Long id);
+
+    @Query("""
+            SELECT c FROM Category c
+            LEFT JOIN FETCH c.parent p
+            LEFT JOIN FETCH p.children
+            WHERE c.id = :id
+            """)
+    Optional<Category> findByIdWithParentAndChildren(@Param("id") Long id);
 
     @Query(value = "SELECT * FROM category WHERE is_deleted = true", nativeQuery = true)
     List<Category> findAllDeleted();
@@ -29,4 +41,40 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByIdIgnoreDeleted(@Param("id") Long parentId);
 
     boolean existsByName(String name);
+
+    @Override
+    default void delete(Category entity) {
+        throw new CustomException(ErrorCode.UNSUPPORTED_OPERATION);
+    }
+
+    @Override
+    default void deleteById(Long id) {
+        throw new CustomException(ErrorCode.UNSUPPORTED_OPERATION);
+    }
+
+    @Override
+    default void deleteAll() {
+        throw new CustomException(ErrorCode.UNSUPPORTED_OPERATION);
+    }
+
+    @Query(value = """
+            WITH RECURSIVE tree AS (
+            SELECT id FROM category WHERE id = :rootId AND is_deleted = false
+            UNION ALL
+            SELECT c.id FROM category c
+            INNER JOIN tree t ON c.parent_id = t.id
+            WHERE c.is_deleted = false
+            )
+            SELECT id FROM tree
+                        """, nativeQuery = true)
+    List<Long> findAllDescendantIds(@Param("rootId") Long rootId);
+
+    @Modifying
+    @Query("UPDATE Category c SET c.isDeleted = true, c.deletedAt = :now WHERE c.id IN :ids")
+    void softDeleteAllByIds(@Param("ids") List<Long> ids, @Param("now") LocalDateTime now);
+
+//    부모 카테고리 복원 시, 자식 카테고리 또한 같이 복원하는 메서드
+//    현재 계획 중인 스팩에서는 사용하지 않지만, 추후 바로 사용할 수 있게 구현
+    @Query(value = "SELECT * FROM category WHERE parent_id = :parentId AND is_deleted = true", nativeQuery = true)
+    List<Category> findDeletedChildrenByParentId(@Param("parentId") Long parentId);
 }

--- a/src/main/java/com/example/commercepilot/category/service/CategoryService.java
+++ b/src/main/java/com/example/commercepilot/category/service/CategoryService.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -42,7 +43,7 @@ public class CategoryService {
     }
 
     public CategoryResponse getCategory(Long categoryId) {
-        Category category = categoryRepository.findById(categoryId)
+        Category category = categoryRepository.findByIdWithParent(categoryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
 
         return CategoryResponse.from(category);
@@ -50,7 +51,7 @@ public class CategoryService {
 
     @Transactional
     public CategoryResponse update(Long categoryId, CategoryUpdateRequest request) {
-        Category category = categoryRepository.findById(categoryId)
+        Category category = categoryRepository.findByIdWithParentAndChildren(categoryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
 
         Category parentCategory = findParentCategory(request.parentCategoryId());
@@ -80,12 +81,21 @@ public class CategoryService {
 
     @Transactional
     public CategoryDeleteResponse delete(Long categoryId) {
-        Category category = categoryRepository.findByIdWithChildren(categoryId)
+        Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
 
-        category.deleteWithDescendants();
+        List<Long> allIds = categoryRepository.findAllDescendantIds(categoryId);
+        LocalDateTime now = LocalDateTime.now();
+        categoryRepository.softDeleteAllByIds(allIds, now);
 
-        return CategoryDeleteResponse.from(category);
+//        @Modifying 벌크 쿼리는 DB만 업데이트하고 영속성 컨텍스트는 건드리지 않는다.
+//        DB에 넣은 삭제 시간을 똑같이 반환할 수 있게 DTO를 직접 구성했다.
+//        return CategoryDeleteResponse.from(category);
+        return CategoryDeleteResponse.builder()
+                .categoryId(category.getId())
+                .categoryName(category.getName())
+                .deletedAt(now)
+                .build();
     }
 
     private Category findParentCategory(Long parentId) {

--- a/src/main/java/com/example/commercepilot/exception/ErrorCode.java
+++ b/src/main/java/com/example/commercepilot/exception/ErrorCode.java
@@ -61,7 +61,8 @@ public enum ErrorCode {
     SELF_REFERENCE_CATEGORY(HttpStatus.BAD_REQUEST, "CA002", "자신을 부모 카테고리로 가질 수 없습니다."),
     CIRCULAR_CATEGORY_REFERENCE(HttpStatus.BAD_REQUEST, "CA003", "자식이 부모가 되는 참조를 만들 수 없습니다."),
     DUPLICATE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "CA004", "해당 카테고리명은 이미 존재합니다."),
-    CATEGORY_PARENT_DELETED(HttpStatus.CONFLICT, "CA005", "부모 카테고리가 삭제된 상태입니다.");
+    CATEGORY_PARENT_DELETED(HttpStatus.CONFLICT, "CA005", "부모 카테고리가 삭제된 상태입니다."),
+    UNSUPPORTED_OPERATION(HttpStatus.BAD_REQUEST, "CA006", "물리적인 삭제는 이용할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/commercepilot/orders/service/OrderService.java
+++ b/src/main/java/com/example/commercepilot/orders/service/OrderService.java
@@ -37,7 +37,7 @@ public class OrderService {
 
     @Transactional
     public OrderCreateResponse add(LoginAdmin loginAdmin, LoginCustomer loginCustomer, OrderCreateRequest request) {
-        Product product = productRepository.findById(request.productId())
+        Product product = productRepository.findByIdWithLock(request.productId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         validateProduct(product, request);
@@ -99,9 +99,11 @@ public class OrderService {
             throw new CustomException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
         }
 
-        Product product = order.getProduct();
-        product.increaseStock(order.getQuantity());
+//        Product product = order.getProduct();
+        Product product = productRepository.findByIdWithLock(order.getProduct().getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
+        product.increaseStock(order.getQuantity());
         order.cancel(request.cancelText());
 
         return OrderDeleteResponse.from(order);

--- a/src/main/java/com/example/commercepilot/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/commercepilot/product/repository/ProductRepository.java
@@ -2,11 +2,15 @@ package com.example.commercepilot.product.repository;
 
 import com.example.commercepilot.product.entity.Product;
 import com.example.commercepilot.product.entity.ProductStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product,Long> {
     @Query("""
@@ -27,4 +31,8 @@ where (:keyword is null or :keyword = '' or p.productName like %:keyword%)
             @Param("status") ProductStatus status,
             Pageable pageable
     );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.id = :id")
+    Optional<Product> findByIdWithLock(@Param("id") Long id);
 }


### PR DESCRIPTION
## 💡 개요
- 카테고리 조회 기능의 N+1 문제와 영속성 전이, 동시성 이슈(비관적인 락 채택) 해결

## 🛠️ 작업 내용
### 카테고리
- 기존: 카테고리 조회 기능을 수행할 때, 연관된 자식 카테고리를 조회하면서 추가적인 N개의 쿼리가 발생
- 수정: FETCH JOIN과 벌크 연산을 사용하여 프록시가 아닌, 엔티티 자체를 한 번에 불러와 N + 1 문제 해결
### 주문
- 기존: 주문 생성/삭제 기능을 수행할 때, 동시에 여러 고객이 하나의 물건을 대상으로 쓰기 작업을 수행할 시, 데이터 불일치 및 제약조건 위반할 가능성 발견 
- 수정: 비관적인 락을 채택하여, 한 명의 고객이 물건에 대해 주문을 진행하고 있으면, 다른 고객은 기다리고 있어야 한다.

## 💬 리뷰 포인트
- 카테고리 조회 기능의 N + 1 문제가 제대로 해결되어, 성능적인 이슈가 사라졌는가?
- 주문 생성/삭제 기능을 수행하면서, 동시에 접근하게 됐을 경우 데이터 불일치나, 기타 문제가 발생하지 않는가?

- Closes: #68 
